### PR TITLE
Release v0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ Thumbs.db
 
 # Claude Code local settings (user-specific, may contain secrets)
 .claude/settings.local.json
+CLAUDE.md
 
 # MCP configuration (contains API tokens)
 .mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-01-20
+
+### Added
+
+- **New Rules**:
+  - SM018: Detects `AddIndexConcurrently` / `RemoveIndexConcurrently` in atomic migrations (PostgreSQL). These operations require `atomic = False`.
+  - SM019: Warns when column names are SQL reserved keywords (user, order, group, type, etc.).
+
+- **Rule Categories**: Group related rules for bulk enable/disable:
+  - Categories: `postgresql`, `indexes`, `constraints`, `destructive`, `locking`, `data-loss`, `reversibility`, `data-migrations`, `high-risk`, `informational`, `naming`, `schema-changes`
+  - New settings: `DISABLED_CATEGORIES`, `ENABLED_CATEGORIES`
+
+- **Per-App Configuration**: Configure rules differently per Django app via `APP_RULES` setting:
+  - Per-app `DISABLED_RULES`, `DISABLED_CATEGORIES`, `ENABLED_CATEGORIES`
+  - Per-app `RULE_SEVERITY` overrides
+
+- **Debug Logging**: Comprehensive logging throughout the analyzer for troubleshooting. Enable with:
+  ```python
+  LOGGING = {
+      'loggers': {
+          'django_safe_migrations': {'level': 'DEBUG'},
+      },
+  }
+  ```
+
+### Changed
+
+- **AST-Based Line Detection**: More accurate line number detection using Python AST parsing instead of bracket counting. Handles comments, multi-line strings, and complex formatting.
+
+- **Smarter AlterField Detection (SM004)**: Reduced false positives by detecting safe changes:
+  - Adding `null=True` (safe)
+  - `TextField` alterations (usually metadata only)
+  - `BooleanField` alterations (typically safe)
+
+### Documentation
+
+- Updated configuration guide with category and per-app settings.
+- Added rule documentation for SM018 and SM019.
+- Updated rules index with new rules.
+
 ## [0.2.0] - 2026-01-19
 
 ### Added
@@ -92,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented detailed security documentation regarding `EXTRA_RULES` and dynamic code loading.
 - Established security reporting policy.
 
-[Unreleased]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/YasserShkeir/django-safe-migrations/compare/v0.1.0...v0.1.1

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -11,6 +11,12 @@ Example::
         # Disable specific rules
         "DISABLED_RULES": ["SM006", "SM008"],
 
+        # Disable entire categories
+        "DISABLED_CATEGORIES": ["reversibility"],
+
+        # Enable only specific categories (whitelist mode)
+        # "ENABLED_CATEGORIES": ["destructive", "postgresql"],
+
         # Change severity levels
         "RULE_SEVERITY": {
             "SM002": "INFO",  # Downgrade to INFO
@@ -21,20 +27,59 @@ Example::
 
         # Fail on warning in addition to errors
         "FAIL_ON_WARNING": False,
+
+        # Per-app rule configuration (overrides global settings)
+        "APP_RULES": {
+            "legacy_app": {
+                "DISABLED_RULES": ["SM001", "SM002"],  # Allow these for legacy
+            },
+            "new_app": {
+                "ENABLED_CATEGORIES": ["high-risk"],  # Only high-risk for new app
+            },
+        },
     }
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django.conf import settings
 
 from django_safe_migrations.rules.base import Severity
 
+logger = logging.getLogger("django_safe_migrations")
+
+# Rule categories for grouping related rules
+# Each category maps to a list of rule IDs
+RULE_CATEGORIES: dict[str, list[str]] = {
+    # Database-specific rules
+    "postgresql": ["SM005", "SM010", "SM011", "SM012", "SM013", "SM018"],
+    "mysql": [],  # Currently no MySQL-specific rules
+    "sqlite": [],  # Currently no SQLite-specific rules
+    # Operation type categories
+    "indexes": ["SM010", "SM011", "SM018"],
+    "constraints": ["SM009", "SM011", "SM015", "SM017"],
+    "destructive": ["SM002", "SM003", "SM009"],
+    # Safety concern categories
+    "locking": ["SM004", "SM005", "SM010", "SM011", "SM013"],
+    "data-loss": ["SM002", "SM003", "SM009"],
+    "reversibility": ["SM007", "SM016", "SM017"],
+    "data-migrations": ["SM007", "SM008", "SM016", "SM017"],
+    # Severity-based categories
+    "high-risk": ["SM001", "SM002", "SM003", "SM010", "SM011", "SM018"],
+    "informational": ["SM006", "SM014", "SM019"],
+    # Feature categories
+    "naming": ["SM019"],
+    "schema-changes": ["SM001", "SM002", "SM003", "SM004", "SM006", "SM013", "SM014"],
+}
+
 # Default configuration values
 DEFAULTS: dict[str, Any] = {
     "DISABLED_RULES": [],
+    "DISABLED_CATEGORIES": [],
+    "ENABLED_CATEGORIES": [],  # Empty = all categories enabled
     "RULE_SEVERITY": {},
     "EXCLUDED_APPS": [
         "admin",
@@ -45,6 +90,7 @@ DEFAULTS: dict[str, Any] = {
         "staticfiles",
     ],
     "FAIL_ON_WARNING": False,
+    "APP_RULES": {},  # Per-app rule configuration
 }
 
 
@@ -146,3 +192,279 @@ def get_rule_severity(rule_id: str, default: Severity) -> Severity:
     """
     overrides = get_severity_overrides()
     return overrides.get(rule_id, default)
+
+
+def get_disabled_categories() -> list[str]:
+    """Get list of disabled category names.
+
+    Returns:
+        A list of category names to disable.
+    """
+    config = get_config()
+    disabled: list[str] = config.get("DISABLED_CATEGORIES", [])
+    return disabled
+
+
+def get_enabled_categories() -> list[str]:
+    """Get list of enabled category names (whitelist mode).
+
+    If empty, all categories are enabled (except those in DISABLED_CATEGORIES).
+
+    Returns:
+        A list of category names to enable (empty = all enabled).
+    """
+    config = get_config()
+    enabled: list[str] = config.get("ENABLED_CATEGORIES", [])
+    return enabled
+
+
+def get_rules_in_category(category: str) -> list[str]:
+    """Get all rule IDs in a category.
+
+    Args:
+        category: The category name.
+
+    Returns:
+        A list of rule IDs in that category.
+    """
+    return RULE_CATEGORIES.get(category, [])
+
+
+def get_all_categories() -> list[str]:
+    """Get all available category names.
+
+    Returns:
+        A list of all category names.
+    """
+    return list(RULE_CATEGORIES.keys())
+
+
+def get_rules_from_categories(categories: list[str]) -> set[str]:
+    """Get all rule IDs from multiple categories.
+
+    Args:
+        categories: List of category names.
+
+    Returns:
+        A set of all rule IDs in those categories.
+    """
+    rules: set[str] = set()
+    for category in categories:
+        rules.update(get_rules_in_category(category))
+    return rules
+
+
+def is_rule_disabled_by_category(rule_id: str) -> bool:
+    """Check if a rule is disabled via category configuration.
+
+    Logic:
+    - If ENABLED_CATEGORIES is set, only rules in those categories are enabled
+    - Rules in DISABLED_CATEGORIES are always disabled
+    - Individual DISABLED_RULES takes precedence
+
+    Args:
+        rule_id: The rule ID to check.
+
+    Returns:
+        True if the rule should be disabled, False otherwise.
+    """
+    enabled_categories = get_enabled_categories()
+    disabled_categories = get_disabled_categories()
+
+    # If whitelist mode (ENABLED_CATEGORIES is set)
+    if enabled_categories:
+        enabled_rules = get_rules_from_categories(enabled_categories)
+        if rule_id not in enabled_rules:
+            logger.debug(
+                "Rule %s disabled: not in enabled categories %s",
+                rule_id,
+                enabled_categories,
+            )
+            return True
+
+    # Check if rule is in a disabled category
+    if disabled_categories:
+        disabled_by_category = get_rules_from_categories(disabled_categories)
+        if rule_id in disabled_by_category:
+            logger.debug(
+                "Rule %s disabled: in disabled categories %s",
+                rule_id,
+                disabled_categories,
+            )
+            return True
+
+    return False
+
+
+def is_rule_enabled(rule_id: str) -> bool:
+    """Check if a rule is enabled (considering all disable mechanisms).
+
+    This checks:
+    1. Individual DISABLED_RULES
+    2. DISABLED_CATEGORIES
+    3. ENABLED_CATEGORIES (whitelist mode)
+
+    Args:
+        rule_id: The rule ID to check.
+
+    Returns:
+        True if the rule should run, False otherwise.
+    """
+    # Check individual disable first
+    if is_rule_disabled(rule_id):
+        return False
+
+    # Check category-based disable
+    if is_rule_disabled_by_category(rule_id):
+        return False
+
+    return True
+
+
+def get_category_for_rule(rule_id: str) -> list[str]:
+    """Get all categories that a rule belongs to.
+
+    Args:
+        rule_id: The rule ID to check.
+
+    Returns:
+        A list of category names the rule belongs to.
+    """
+    categories = []
+    for category, rules in RULE_CATEGORIES.items():
+        if rule_id in rules:
+            categories.append(category)
+    return categories
+
+
+# -----------------------------------------------------------------------------
+# Per-App Configuration
+# -----------------------------------------------------------------------------
+
+
+def get_app_rules_config() -> dict[str, dict[str, Any]]:
+    """Get the per-app rules configuration.
+
+    Returns:
+        A dictionary mapping app labels to their rule configurations.
+    """
+    config = get_config()
+    app_rules: dict[str, dict[str, Any]] = config.get("APP_RULES", {})
+    return app_rules
+
+
+def get_app_config(app_label: str) -> dict[str, Any]:
+    """Get the rule configuration for a specific app.
+
+    Args:
+        app_label: The app label (e.g., 'myapp').
+
+    Returns:
+        The app-specific configuration, or empty dict if not configured.
+    """
+    app_rules = get_app_rules_config()
+    return app_rules.get(app_label, {})
+
+
+def is_rule_enabled_for_app(rule_id: str, app_label: str | None = None) -> bool:
+    """Check if a rule is enabled for a specific app.
+
+    This function checks rule enablement with the following precedence:
+    1. App-specific DISABLED_RULES
+    2. App-specific DISABLED_CATEGORIES / ENABLED_CATEGORIES
+    3. Global DISABLED_RULES
+    4. Global DISABLED_CATEGORIES / ENABLED_CATEGORIES
+
+    Args:
+        rule_id: The rule ID to check.
+        app_label: The app label. If None, uses global configuration only.
+
+    Returns:
+        True if the rule should run for this app, False otherwise.
+    """
+    # If no app specified, use global configuration
+    if app_label is None:
+        return is_rule_enabled(rule_id)
+
+    # Get app-specific configuration
+    app_config = get_app_config(app_label)
+
+    # If no app-specific config, fall back to global
+    if not app_config:
+        return is_rule_enabled(rule_id)
+
+    # Check app-specific DISABLED_RULES first
+    app_disabled_rules = app_config.get("DISABLED_RULES", [])
+    if rule_id in app_disabled_rules:
+        logger.debug(
+            "Rule %s disabled for app %s: in app DISABLED_RULES",
+            rule_id,
+            app_label,
+        )
+        return False
+
+    # Check app-specific category configuration
+    app_enabled_categories = app_config.get("ENABLED_CATEGORIES", [])
+    app_disabled_categories = app_config.get("DISABLED_CATEGORIES", [])
+
+    # App-level whitelist mode
+    if app_enabled_categories:
+        enabled_rules = get_rules_from_categories(app_enabled_categories)
+        if rule_id not in enabled_rules:
+            logger.debug(
+                "Rule %s disabled for app %s: not in app ENABLED_CATEGORIES %s",
+                rule_id,
+                app_label,
+                app_enabled_categories,
+            )
+            return False
+
+    # App-level disabled categories
+    if app_disabled_categories:
+        disabled_by_category = get_rules_from_categories(app_disabled_categories)
+        if rule_id in disabled_by_category:
+            logger.debug(
+                "Rule %s disabled for app %s: in app DISABLED_CATEGORIES %s",
+                rule_id,
+                app_label,
+                app_disabled_categories,
+            )
+            return False
+
+    # If app has any configuration but didn't disable this rule,
+    # still check global configuration
+    return is_rule_enabled(rule_id)
+
+
+def get_rule_severity_for_app(
+    rule_id: str, default: Severity, app_label: str | None = None
+) -> Severity:
+    """Get the severity for a rule, considering app-specific overrides.
+
+    Args:
+        rule_id: The rule ID to check.
+        default: The default severity if no override exists.
+        app_label: The app label. If None, uses global configuration only.
+
+    Returns:
+        The configured severity for the rule.
+    """
+    # Check app-specific severity first
+    if app_label:
+        app_config = get_app_config(app_label)
+        app_severity = app_config.get("RULE_SEVERITY", {})
+        if rule_id in app_severity:
+            severity_str = app_severity[rule_id]
+            if isinstance(severity_str, str):
+                try:
+                    return Severity(severity_str.lower())
+                except ValueError:
+                    if hasattr(Severity, severity_str.upper()):
+                        result = getattr(Severity, severity_str.upper())
+                        if isinstance(result, Severity):
+                            return result
+            elif isinstance(severity_str, Severity):
+                return severity_str
+
+    # Fall back to global severity
+    return get_rule_severity(rule_id, default)

--- a/django_safe_migrations/rules/__init__.py
+++ b/django_safe_migrations/rules/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from django_safe_migrations.rules.add_field import NotNullWithoutDefaultRule
 from django_safe_migrations.rules.add_index import (
+    ConcurrentInAtomicMigrationRule,
     UnsafeIndexCreationRule,
     UnsafeUniqueConstraintRule,
 )
@@ -20,6 +21,7 @@ from django_safe_migrations.rules.constraints import (
     AddUniqueConstraintRule,
     AlterUniqueTogetherRule,
 )
+from django_safe_migrations.rules.naming import ReservedKeywordColumnRule
 from django_safe_migrations.rules.remove_field import (
     DropColumnUnsafeRule,
     DropTableUnsafeRule,
@@ -55,9 +57,12 @@ __all__ = [
     "AddUniqueConstraintRule",
     "AlterUniqueTogetherRule",
     "AddCheckConstraintRule",
-    # SM010-SM011 - Index rules
+    # SM010-SM011, SM018 - Index rules
     "UnsafeIndexCreationRule",
     "UnsafeUniqueConstraintRule",
+    "ConcurrentInAtomicMigrationRule",
+    # SM019 - Naming rules
+    "ReservedKeywordColumnRule",
     # Functions
     "get_all_rules",
     "get_rules_for_db",
@@ -81,13 +86,16 @@ ALL_RULES: list[type[BaseRule]] = [
     AddUniqueConstraintRule,
     AlterUniqueTogetherRule,
     AddCheckConstraintRule,
-    # Index rules (SM010-SM011)
+    # Index rules (SM010-SM011, SM018)
     UnsafeIndexCreationRule,
     UnsafeUniqueConstraintRule,
+    ConcurrentInAtomicMigrationRule,
     # PostgreSQL specific (SM012-SM014)
     EnumAddValueInTransactionRule,
     AlterVarcharLengthRule,
     RenameModelRule,
+    # Naming rules (SM019)
+    ReservedKeywordColumnRule,
 ]
 
 

--- a/django_safe_migrations/rules/naming.py
+++ b/django_safe_migrations/rules/naming.py
@@ -1,0 +1,470 @@
+"""Rules for naming conventions and reserved keywords."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from django.db import migrations
+
+from django_safe_migrations.rules.base import BaseRule, Issue, Severity
+
+if TYPE_CHECKING:
+    from django.db.migrations import Migration
+    from django.db.migrations.operations.base import Operation
+
+logger = logging.getLogger("django_safe_migrations")
+
+# SQL reserved keywords that are commonly problematic
+# This is a subset of reserved words across PostgreSQL, MySQL, and SQLite
+# Full lists are much longer, but these are the most commonly encountered
+SQL_RESERVED_KEYWORDS = frozenset(
+    {
+        # SQL standard keywords
+        "all",
+        "and",
+        "any",
+        "as",
+        "asc",
+        "between",
+        "by",
+        "case",
+        "check",
+        "column",
+        "constraint",
+        "create",
+        "cross",
+        "current",
+        "default",
+        "delete",
+        "desc",
+        "distinct",
+        "drop",
+        "else",
+        "end",
+        "exists",
+        "false",
+        "for",
+        "foreign",
+        "from",
+        "full",
+        "group",
+        "having",
+        "in",
+        "index",
+        "inner",
+        "insert",
+        "into",
+        "is",
+        "join",
+        "key",
+        "left",
+        "like",
+        "limit",
+        "not",
+        "null",
+        "on",
+        "or",
+        "order",
+        "outer",
+        "primary",
+        "references",
+        "right",
+        "select",
+        "set",
+        "table",
+        "then",
+        "to",
+        "true",
+        "union",
+        "unique",
+        "update",
+        "using",
+        "values",
+        "when",
+        "where",
+        "with",
+        # Common problematic names
+        "user",
+        "users",
+        "order",
+        "orders",
+        "group",
+        "groups",
+        "type",
+        "status",
+        "name",
+        "date",
+        "time",
+        "timestamp",
+        "key",
+        "value",
+        "comment",
+        "admin",
+        "level",
+        "rank",
+        "row",
+        "rows",
+        "count",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "offset",
+        "result",
+        "action",
+        "mode",
+        "role",
+        "session",
+    }
+)
+
+# PostgreSQL-specific reserved words
+POSTGRESQL_RESERVED = frozenset(
+    {
+        "analyse",
+        "analyze",
+        "array",
+        "asymmetric",
+        "both",
+        "cast",
+        "collate",
+        "current_catalog",
+        "current_date",
+        "current_role",
+        "current_schema",
+        "current_time",
+        "current_timestamp",
+        "current_user",
+        "deferrable",
+        "do",
+        "except",
+        "fetch",
+        "freeze",
+        "grant",
+        "ilike",
+        "initially",
+        "intersect",
+        "isnull",
+        "lateral",
+        "leading",
+        "localtime",
+        "localtimestamp",
+        "natural",
+        "notnull",
+        "only",
+        "overlaps",
+        "placing",
+        "returning",
+        "similar",
+        "some",
+        "symmetric",
+        "trailing",
+        "user",
+        "variadic",
+        "verbose",
+        "window",
+    }
+)
+
+# MySQL-specific reserved words
+MYSQL_RESERVED = frozenset(
+    {
+        "accessible",
+        "add",
+        "alter",
+        "analyze",
+        "asensitive",
+        "before",
+        "bigint",
+        "binary",
+        "blob",
+        "both",
+        "call",
+        "cascade",
+        "change",
+        "char",
+        "character",
+        "collate",
+        "condition",
+        "continue",
+        "convert",
+        "database",
+        "databases",
+        "day_hour",
+        "day_microsecond",
+        "day_minute",
+        "day_second",
+        "dec",
+        "decimal",
+        "declare",
+        "delayed",
+        "describe",
+        "deterministic",
+        "distinctrow",
+        "div",
+        "double",
+        "dual",
+        "each",
+        "elseif",
+        "enclosed",
+        "escaped",
+        "exit",
+        "explain",
+        "float",
+        "float4",
+        "float8",
+        "force",
+        "fulltext",
+        "generated",
+        "get",
+        "high_priority",
+        "hour_microsecond",
+        "hour_minute",
+        "hour_second",
+        "if",
+        "ignore",
+        "infile",
+        "inout",
+        "insensitive",
+        "int",
+        "int1",
+        "int2",
+        "int3",
+        "int4",
+        "int8",
+        "integer",
+        "interval",
+        "io_after_gtids",
+        "io_before_gtids",
+        "iterate",
+        "keys",
+        "kill",
+        "leading",
+        "leave",
+        "linear",
+        "lines",
+        "load",
+        "localtime",
+        "localtimestamp",
+        "lock",
+        "long",
+        "longblob",
+        "longtext",
+        "loop",
+        "low_priority",
+        "master_bind",
+        "master_ssl_verify_server_cert",
+        "match",
+        "maxvalue",
+        "mediumblob",
+        "mediumint",
+        "mediumtext",
+        "middleint",
+        "minute_microsecond",
+        "minute_second",
+        "mod",
+        "modifies",
+        "natural",
+        "no_write_to_binlog",
+        "numeric",
+        "optimize",
+        "option",
+        "optionally",
+        "out",
+        "outfile",
+        "partition",
+        "precision",
+        "procedure",
+        "purge",
+        "range",
+        "read",
+        "reads",
+        "real",
+        "regexp",
+        "release",
+        "rename",
+        "repeat",
+        "replace",
+        "require",
+        "resignal",
+        "restrict",
+        "return",
+        "revoke",
+        "rlike",
+        "schema",
+        "schemas",
+        "second_microsecond",
+        "sensitive",
+        "separator",
+        "show",
+        "signal",
+        "smallint",
+        "spatial",
+        "specific",
+        "sql",
+        "sql_big_result",
+        "sql_calc_found_rows",
+        "sql_small_result",
+        "sqlexception",
+        "sqlstate",
+        "sqlwarning",
+        "ssl",
+        "starting",
+        "stored",
+        "straight_join",
+        "terminated",
+        "tinyblob",
+        "tinyint",
+        "tinytext",
+        "trigger",
+        "undo",
+        "unlock",
+        "unsigned",
+        "usage",
+        "use",
+        "utc_date",
+        "utc_time",
+        "utc_timestamp",
+        "varbinary",
+        "varchar",
+        "varcharacter",
+        "varying",
+        "virtual",
+        "while",
+        "write",
+        "xor",
+        "year_month",
+        "zerofill",
+    }
+)
+
+
+class ReservedKeywordColumnRule(BaseRule):
+    """Detect column names that are SQL reserved keywords.
+
+    Using SQL reserved keywords as column names can cause issues:
+    1. Raw SQL queries may fail without proper quoting
+    2. Some ORMs and tools may not quote identifiers properly
+    3. Database migrations and dumps may have compatibility issues
+    4. Debugging and maintenance becomes harder
+
+    Django quotes identifiers automatically in ORM queries, but raw SQL,
+    database tools, and third-party libraries may not.
+
+    Severity is INFO because this is a best practice warning,
+    not a blocking issue.
+    """
+
+    rule_id = "SM019"
+    severity = Severity.INFO
+    description = "Column name is a SQL reserved keyword"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Check if operation uses a reserved keyword as column name.
+
+        Args:
+            operation: The migration operation to check.
+            migration: The migration containing the operation.
+            **kwargs: Additional context (may include db_vendor).
+
+        Returns:
+            An Issue if a reserved keyword is used, None otherwise.
+        """
+        # Check AddField operations
+        db_vendor: str | None = kwargs.get("db_vendor")  # type: ignore[assignment]
+        if isinstance(operation, migrations.AddField):
+            field_name = operation.name.lower()
+            if self._is_reserved_keyword(field_name, db_vendor):
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        f"Column name '{operation.name}' on "
+                        f"'{operation.model_name}' is a SQL reserved keyword"
+                    ),
+                )
+
+        # Check CreateModel operations for all fields
+        if isinstance(operation, migrations.CreateModel):
+            reserved_fields = []
+            for field_name, _field in operation.fields:
+                if self._is_reserved_keyword(field_name.lower(), db_vendor):
+                    reserved_fields.append(field_name)
+
+            if reserved_fields:
+                fields_str = ", ".join(f"'{f}'" for f in reserved_fields)
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        f"Model '{operation.name}' has fields with reserved "
+                        f"keyword names: {fields_str}"
+                    ),
+                )
+
+        return None
+
+    def _is_reserved_keyword(self, name: str, db_vendor: str | None = None) -> bool:
+        """Check if a name is a SQL reserved keyword.
+
+        Args:
+            name: The column/field name to check (lowercase).
+            db_vendor: Optional database vendor for vendor-specific checks.
+
+        Returns:
+            True if the name is a reserved keyword.
+        """
+        # Check common SQL keywords
+        if name in SQL_RESERVED_KEYWORDS:
+            return True
+
+        # Check vendor-specific keywords if vendor is specified
+        if db_vendor == "postgresql" and name in POSTGRESQL_RESERVED:
+            return True
+
+        if db_vendor in ("mysql", "mariadb") and name in MYSQL_RESERVED:
+            return True
+
+        return False
+
+    def get_suggestion(self, operation: Operation) -> str:
+        """Return suggestion for handling reserved keyword names.
+
+        Args:
+            operation: The problematic operation.
+
+        Returns:
+            A multi-line string with suggestions.
+        """
+        if isinstance(operation, migrations.AddField):
+            field_name = operation.name
+        else:
+            field_name = "field_name"
+
+        return f"""Recommended alternatives for reserved keyword column names:
+
+1. Use a more descriptive name:
+   - Instead of 'user' → 'user_id', 'created_by', 'author'
+   - Instead of 'order' → 'sort_order', 'sequence', 'display_order'
+   - Instead of 'type' → 'item_type', 'category', 'kind'
+   - Instead of 'status' → 'order_status', 'current_state'
+
+2. Use db_column to keep the model field name different from DB column:
+   class MyModel(models.Model):
+       order_number = models.IntegerField(db_column='order')
+
+3. If you must use a reserved word, Django will quote it in ORM queries,
+   but be careful with:
+   - Raw SQL queries (always quote identifiers)
+   - Database tools and GUIs
+   - Third-party libraries accessing the database
+   - Exported SQL dumps
+
+Current field name: '{field_name}'
+"""

--- a/docs/rules/SM018.md
+++ b/docs/rules/SM018.md
@@ -1,0 +1,79 @@
+# SM018: Concurrent operations require atomic = False
+
+**Severity:** ERROR
+**Database:** PostgreSQL only
+**Category:** indexes, postgresql, high-risk
+
+## Description
+
+PostgreSQL's `AddIndexConcurrently` and `RemoveIndexConcurrently` operations cannot run inside a database transaction. Django migrations are atomic by default (`atomic = True`), which wraps all operations in a transaction.
+
+Using concurrent index operations in an atomic migration will fail with:
+
+```
+django.db.utils.OperationalError: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
+```
+
+## Examples
+
+### ❌ Incorrect
+
+```python
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    # atomic = True is the default - concurrent operations will fail!
+
+    operations = [
+        AddIndexConcurrently(
+            model_name='article',
+            index=models.Index(fields=['title'], name='article_title_idx'),
+        ),
+    ]
+```
+
+### ✅ Correct
+
+```python
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for concurrent operations
+
+    operations = [
+        AddIndexConcurrently(
+            model_name='article',
+            index=models.Index(fields=['title'], name='article_title_idx'),
+        ),
+    ]
+```
+
+## Why This Matters
+
+1. **Migrations will fail** — Without `atomic = False`, concurrent operations cannot execute
+2. **Production deployments break** — This error only appears at runtime, potentially during deployment
+3. **Easy to miss** — The migration will appear to work in development if not tested properly
+
+## How to Fix
+
+Add `atomic = False` to your migration class:
+
+```python
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [...]
+    operations = [...]
+```
+
+## Related Rules
+
+- [SM010](SM010.md) — Unsafe index creation (recommends using `AddIndexConcurrently`)
+- [SM011](SM011.md) — Unsafe unique constraint (recommends concurrent index approach)
+
+## References
+
+- [Django PostgreSQL specific operations](https://docs.djangoproject.com/en/stable/ref/contrib/postgres/operations/)
+- [PostgreSQL CREATE INDEX CONCURRENTLY](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY)

--- a/docs/rules/SM019.md
+++ b/docs/rules/SM019.md
@@ -1,0 +1,145 @@
+# SM019: Column name is a SQL reserved keyword
+
+**Severity:** INFO
+**Database:** All (PostgreSQL, MySQL, SQLite)
+**Category:** naming, informational
+
+## Description
+
+Using SQL reserved keywords as column names can cause issues with raw SQL queries, database tools, and third-party libraries that don't properly quote identifiers.
+
+While Django's ORM automatically quotes identifiers, this rule warns about potential problems when working outside the ORM.
+
+## Examples
+
+### ❌ Problematic Names
+
+```python
+migrations.AddField(
+    model_name='article',
+    name='order',  # Reserved keyword
+    field=models.IntegerField(),
+)
+
+migrations.AddField(
+    model_name='profile',
+    name='user',  # Reserved in PostgreSQL
+    field=models.ForeignKey('auth.User', on_delete=models.CASCADE),
+)
+
+migrations.CreateModel(
+    name='Item',
+    fields=[
+        ('id', models.AutoField(primary_key=True)),
+        ('type', models.CharField(max_length=50)),  # Reserved
+        ('status', models.CharField(max_length=20)),  # Reserved
+    ],
+)
+```
+
+### ✅ Recommended Names
+
+```python
+migrations.AddField(
+    model_name='article',
+    name='sort_order',  # More descriptive
+    field=models.IntegerField(),
+)
+
+migrations.AddField(
+    model_name='profile',
+    name='owner',  # Avoids reserved word
+    field=models.ForeignKey('auth.User', on_delete=models.CASCADE),
+)
+
+migrations.CreateModel(
+    name='Item',
+    fields=[
+        ('id', models.AutoField(primary_key=True)),
+        ('item_type', models.CharField(max_length=50)),
+        ('current_status', models.CharField(max_length=20)),
+    ],
+)
+```
+
+## Common Reserved Keywords
+
+The following are commonly problematic column names:
+
+| Keyword  | Better Alternatives                        |
+| -------- | ------------------------------------------ |
+| `user`   | `owner`, `created_by`, `author`, `user_id` |
+| `order`  | `sort_order`, `sequence`, `display_order`  |
+| `group`  | `group_name`, `category`, `team`           |
+| `type`   | `item_type`, `category`, `kind`            |
+| `status` | `current_status`, `order_status`, `state`  |
+| `name`   | `title`, `label`, `display_name`           |
+| `key`    | `lookup_key`, `api_key`, `identifier`      |
+| `value`  | `amount`, `content`, `data`                |
+| `date`   | `created_date`, `event_date`, `due_date`   |
+| `time`   | `start_time`, `duration`, `timestamp`      |
+
+## Why This Matters
+
+1. **Raw SQL queries fail** — Unquoted identifiers cause syntax errors:
+
+   ```sql
+   -- Fails!
+   SELECT user, order FROM profile;
+
+   -- Works but cumbersome
+   SELECT "user", "order" FROM profile;
+   ```
+
+2. **Database tools have issues** — GUI tools, export utilities, and reporting tools may not handle reserved words correctly
+
+3. **Third-party libraries** — ORMs, query builders, and analytics tools may not quote identifiers properly
+
+4. **Debugging is harder** — Stack traces and error messages become confusing
+
+## How to Fix
+
+### Option 1: Use a more descriptive name (Recommended)
+
+```python
+# Instead of 'order'
+name='sort_order'
+name='display_order'
+name='sequence_number'
+```
+
+### Option 2: Use `db_column` to keep model clean
+
+If you want a clean model field name but a different database column:
+
+```python
+class Article(models.Model):
+    order_number = models.IntegerField(db_column='article_order')
+```
+
+### Option 3: Accept and document
+
+If you must use a reserved word, Django will quote it correctly in ORM queries. Just be careful with:
+
+- Raw SQL queries
+- Database migrations and dumps
+- Third-party integrations
+
+## Detected Keywords
+
+This rule checks for SQL reserved keywords from:
+
+- SQL standard (SELECT, INSERT, UPDATE, DELETE, etc.)
+- PostgreSQL specific (ANALYSE, FREEZE, VERBOSE, etc.)
+- MySQL specific (DATABASE, SCHEMA, etc.)
+- Common problematic names (user, order, group, type, etc.)
+
+## Related Rules
+
+- [SM006](SM006.md) — Column rename detection
+
+## References
+
+- [PostgreSQL Reserved Keywords](https://www.postgresql.org/docs/current/sql-keywords-appendix.html)
+- [MySQL Reserved Keywords](https://dev.mysql.com/doc/refman/8.0/en/keywords.html)
+- [SQLite Keywords](https://www.sqlite.org/lang_keywords.html)

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -42,6 +42,7 @@ This section documents each rule in detail, explaining:
 | [SM011](SM011.md) | ERROR    | Unique constraint without concurrent index (PostgreSQL) |
 | [SM015](SM015.md) | WARNING  | Using deprecated unique_together                        |
 | [SM017](SM017.md) | WARNING  | Adding CHECK constraint (validates rows)                |
+| [SM018](SM018.md) | ERROR    | Concurrent operations require atomic = False            |
 
 ### RunSQL & RunPython
 
@@ -51,6 +52,12 @@ This section documents each rule in detail, explaining:
 | [SM008](SM008.md) | INFO     | RunPython data migration                         |
 | [SM012](SM012.md) | ERROR    | ALTER TYPE ADD VALUE in transaction (PostgreSQL) |
 | [SM016](SM016.md) | INFO     | RunPython without reverse_code                   |
+
+### Naming Conventions
+
+| Rule              | Severity | Description                           |
+| ----------------- | -------- | ------------------------------------- |
+| [SM019](SM019.md) | INFO     | Column name is a SQL reserved keyword |
 
 ## Severity Levels
 
@@ -80,4 +87,6 @@ SM014  WARNING  rename_model                Renaming model/table
 SM015  WARNING  alter_unique_together       Deprecated unique_together
 SM016  INFO     run_python_no_reverse       RunPython without reverse
 SM017  WARNING  check_constraint            CHECK validates rows
+SM018  ERROR    concurrent_in_atomic        Concurrent op in atomic migration
+SM019  INFO     reserved_keyword_column     Column name is SQL reserved keyword
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.2.0"
+version = "0.3.0"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_project/testapp/migrations/0012_concurrent_index_in_atomic.py
+++ b/tests/test_project/testapp/migrations/0012_concurrent_index_in_atomic.py
@@ -1,0 +1,35 @@
+"""Unsafe migration: concurrent index operation in atomic migration.
+
+This migration should be flagged by SM018 on PostgreSQL.
+AddIndexConcurrently cannot run inside a transaction block.
+"""
+
+from django.db import migrations, models
+
+# Import conditionally to support older Django versions
+try:
+    from django.contrib.postgres.operations import AddIndexConcurrently
+except ImportError:
+    AddIndexConcurrently = None
+
+
+class Migration(migrations.Migration):
+    """Add concurrent index without atomic = False."""
+
+    dependencies = [
+        ("testapp", "0011_suppressed_not_null"),
+    ]
+
+    # Note: atomic = True is the default, which is wrong for concurrent ops
+    # atomic = False  # This should be uncommented to fix the issue
+
+    operations = (
+        [
+            AddIndexConcurrently(
+                model_name="user",
+                index=models.Index(fields=["name"], name="user_name_concurrent_idx"),
+            ),
+        ]
+        if AddIndexConcurrently
+        else []
+    )

--- a/tests/test_project/testapp/migrations/0013_reserved_keyword_field.py
+++ b/tests/test_project/testapp/migrations/0013_reserved_keyword_field.py
@@ -1,0 +1,30 @@
+"""Migration with reserved keyword column names.
+
+This migration should be flagged by SM019 (INFO level).
+Using SQL reserved keywords as column names can cause issues.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add fields with reserved keyword names."""
+
+    dependencies = [
+        ("testapp", "0012_concurrent_index_in_atomic"),
+    ]
+
+    operations = [
+        # 'order' is a SQL reserved keyword
+        migrations.AddField(
+            model_name="user",
+            name="order",
+            field=models.IntegerField(default=0),
+        ),
+        # 'type' is also a reserved keyword
+        migrations.AddField(
+            model_name="user",
+            name="type",
+            field=models.CharField(max_length=50, default="default"),
+        ),
+    ]

--- a/tests/unit/rules/test_add_index_rules.py
+++ b/tests/unit/rules/test_add_index_rules.py
@@ -1,8 +1,11 @@
 """Tests for AddIndex rules."""
 
+from unittest.mock import MagicMock
+
 from django.db import migrations, models
 
 from django_safe_migrations.rules.add_index import (
+    ConcurrentInAtomicMigrationRule,
     UnsafeIndexCreationRule,
     UnsafeUniqueConstraintRule,
 )
@@ -116,3 +119,107 @@ class TestUnsafeUniqueConstraintRule:
         assert suggestion is not None
         assert "concurrent" in suggestion.lower()
         assert "USING INDEX" in suggestion
+
+
+class TestConcurrentInAtomicMigrationRule:
+    """Tests for ConcurrentInAtomicMigrationRule (SM018)."""
+
+    def _create_mock_concurrent_operation(self, op_class_name: str):
+        """Create a mock concurrent operation."""
+        mock_op = MagicMock()
+        mock_op.__class__.__name__ = op_class_name
+        mock_op.model_name = "user"
+        return mock_op
+
+    def test_detects_add_index_concurrently_in_atomic_migration(self, mock_migration):
+        """Test that rule detects AddIndexConcurrently in atomic migration."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = self._create_mock_concurrent_operation("AddIndexConcurrently")
+
+        # Default migration is atomic (atomic=True implied)
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM018"
+        assert issue.severity == Severity.ERROR
+        assert "atomic = False" in issue.message
+        assert "AddIndexConcurrently" in issue.message
+
+    def test_detects_remove_index_concurrently_in_atomic_migration(
+        self, mock_migration
+    ):
+        """Test that rule detects RemoveIndexConcurrently in atomic migration."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = self._create_mock_concurrent_operation("RemoveIndexConcurrently")
+
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM018"
+        assert "RemoveIndexConcurrently" in issue.message
+
+    def test_allows_concurrent_in_non_atomic_migration(self):
+        """Test that rule allows concurrent operations when atomic=False."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = self._create_mock_concurrent_operation("AddIndexConcurrently")
+
+        # Create migration with atomic = False
+        mock_migration = MagicMock()
+        mock_migration.atomic = False
+        mock_migration.__module__ = "testapp.migrations.0001_initial"
+
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is None
+
+    def test_ignores_non_concurrent_operations(self, mock_migration):
+        """Test that rule ignores regular AddIndex operations."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = migrations.AddIndex(
+            model_name="user",
+            index=models.Index(fields=["email"], name="user_email_idx"),
+        )
+
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is None
+
+    def test_ignores_other_operations(self, not_null_field_operation, mock_migration):
+        """Test that rule ignores non-index operations."""
+        rule = ConcurrentInAtomicMigrationRule()
+        issue = rule.check(not_null_field_operation, mock_migration)
+
+        assert issue is None
+
+    def test_only_applies_to_postgresql(self):
+        """Test that rule only applies to PostgreSQL."""
+        rule = ConcurrentInAtomicMigrationRule()
+
+        assert rule.applies_to_db("postgresql") is True
+        assert rule.applies_to_db("mysql") is False
+        assert rule.applies_to_db("sqlite") is False
+
+    def test_provides_suggestion(self):
+        """Test that rule provides a helpful suggestion."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = self._create_mock_concurrent_operation("AddIndexConcurrently")
+
+        suggestion = rule.get_suggestion(operation)
+
+        assert suggestion is not None
+        assert "atomic = False" in suggestion
+        assert "AddIndexConcurrently" in suggestion
+
+    def test_explicit_atomic_true_still_flagged(self):
+        """Test that explicit atomic=True is still flagged."""
+        rule = ConcurrentInAtomicMigrationRule()
+        operation = self._create_mock_concurrent_operation("AddIndexConcurrently")
+
+        mock_migration = MagicMock()
+        mock_migration.atomic = True  # Explicitly True
+        mock_migration.__module__ = "testapp.migrations.0001_initial"
+
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM018"

--- a/tests/unit/rules/test_naming_rules.py
+++ b/tests/unit/rules/test_naming_rules.py
@@ -1,0 +1,203 @@
+"""Tests for naming rules."""
+
+from django.db import migrations, models
+
+from django_safe_migrations.rules.base import Severity
+from django_safe_migrations.rules.naming import ReservedKeywordColumnRule
+
+
+class TestReservedKeywordColumnRule:
+    """Tests for ReservedKeywordColumnRule (SM019)."""
+
+    def test_detects_reserved_keyword_in_addfield(self, mock_migration):
+        """Test that rule detects reserved keywords in AddField operations."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="article",
+            name="order",  # Reserved keyword
+            field=models.IntegerField(),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM019"
+        assert issue.severity == Severity.INFO
+        assert "order" in issue.message
+        assert "reserved" in issue.message.lower()
+
+    def test_detects_user_as_reserved_keyword(self, mock_migration):
+        """Test that 'user' is detected as reserved (common PostgreSQL issue)."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="profile",
+            name="user",  # Reserved in PostgreSQL
+            field=models.ForeignKey(
+                to="auth.User",
+                on_delete=models.CASCADE,
+            ),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM019"
+        assert "user" in issue.message
+
+    def test_detects_group_as_reserved_keyword(self, mock_migration):
+        """Test that 'group' is detected as reserved."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="membership",
+            name="group",
+            field=models.ForeignKey(
+                to="auth.Group",
+                on_delete=models.CASCADE,
+            ),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert "group" in issue.message
+
+    def test_detects_select_as_reserved_keyword(self, mock_migration):
+        """Test that SQL statement keywords are detected."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="choice",
+            name="select",  # SQL keyword
+            field=models.BooleanField(default=False),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert "select" in issue.message
+
+    def test_allows_non_reserved_names(self, mock_migration):
+        """Test that non-reserved names are allowed."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="article",
+            name="title",  # Not reserved
+            field=models.CharField(max_length=255),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is None
+
+    def test_allows_descriptive_variations(self, mock_migration):
+        """Test that descriptive variations of reserved words are allowed."""
+        rule = ReservedKeywordColumnRule()
+
+        # These are not reserved keywords
+        safe_names = ["order_number", "user_id", "created_by", "group_name"]
+
+        for name in safe_names:
+            operation = migrations.AddField(
+                model_name="model",
+                name=name,
+                field=models.CharField(max_length=100),
+            )
+            issue = rule.check(operation, mock_migration)
+            assert issue is None, f"Expected {name} to be allowed"
+
+    def test_case_insensitive_detection(self, mock_migration):
+        """Test that detection is case-insensitive."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="article",
+            name="ORDER",  # Uppercase
+            field=models.IntegerField(),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+
+    def test_detects_in_createmodel(self, mock_migration):
+        """Test that rule checks CreateModel fields."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.CreateModel(
+            name="Article",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("title", models.CharField(max_length=255)),
+                ("order", models.IntegerField()),  # Reserved
+            ],
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM019"
+        assert "order" in issue.message
+
+    def test_detects_multiple_reserved_in_createmodel(self, mock_migration):
+        """Test that rule lists all reserved keywords in CreateModel."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.CreateModel(
+            name="BadModel",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("user", models.IntegerField()),  # Reserved
+                ("order", models.IntegerField()),  # Reserved
+                ("title", models.CharField(max_length=255)),  # OK
+            ],
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        # Should mention both reserved fields
+        assert "user" in issue.message or "order" in issue.message
+
+    def test_ignores_non_field_operations(self, mock_migration):
+        """Test that rule ignores non-field operations."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.DeleteModel(name="OldModel")
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is None
+
+    def test_applies_to_all_databases(self):
+        """Test that rule applies to all database vendors."""
+        rule = ReservedKeywordColumnRule()
+
+        assert rule.applies_to_db("postgresql") is True
+        assert rule.applies_to_db("mysql") is True
+        assert rule.applies_to_db("sqlite") is True
+
+    def test_provides_suggestion(self):
+        """Test that rule provides a helpful suggestion."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="article",
+            name="order",
+            field=models.IntegerField(),
+        )
+        suggestion = rule.get_suggestion(operation)
+
+        assert suggestion is not None
+        assert "db_column" in suggestion
+        assert "order" in suggestion
+
+    def test_detects_type_as_reserved(self, mock_migration):
+        """Test that 'type' is detected as reserved (common Django issue)."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="item",
+            name="type",
+            field=models.CharField(max_length=50),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert "type" in issue.message
+
+    def test_detects_status_as_reserved(self, mock_migration):
+        """Test that 'status' is detected (commonly problematic)."""
+        rule = ReservedKeywordColumnRule()
+        operation = migrations.AddField(
+            model_name="order",
+            name="status",
+            field=models.CharField(max_length=20),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert "status" in issue.message

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -159,18 +159,20 @@ class TestMigrationAnalyzer:
         assert not any(issue.rule_id == "SM001" for issue in issues)
         assert any(issue.rule_id == "SM002" for issue in issues)
 
-    def test_is_rule_disabled_method(self, mock_migration_factory):
-        """Test the _is_rule_disabled method."""
+    def test_is_rule_enabled_method(self, mock_migration_factory):
+        """Test the _is_rule_enabled method."""
         analyzer_with_disabled = MigrationAnalyzer(
             db_vendor="postgresql",
             disabled_rules=["SM006", "SM008"],
         )
 
-        assert analyzer_with_disabled._is_rule_disabled("SM006") is True
-        assert analyzer_with_disabled._is_rule_disabled("SM008") is True
-        assert analyzer_with_disabled._is_rule_disabled("SM001") is False
+        # Disabled rules should return False for is_rule_enabled
+        assert analyzer_with_disabled._is_rule_enabled("SM006") is False
+        assert analyzer_with_disabled._is_rule_enabled("SM008") is False
+        # Non-disabled rules should return True
+        assert analyzer_with_disabled._is_rule_enabled("SM001") is True
 
         # Without explicit disabled_rules, it should check settings
         analyzer_default = MigrationAnalyzer(db_vendor="postgresql")
-        # Will return False unless settings have DISABLED_RULES
-        assert isinstance(analyzer_default._is_rule_disabled("SM001"), bool)
+        # Will return True unless settings have DISABLED_RULES or DISABLED_CATEGORIES
+        assert isinstance(analyzer_default._is_rule_enabled("SM001"), bool)

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -5,13 +5,26 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from django_safe_migrations.conf import (
+    RULE_CATEGORIES,
+    get_all_categories,
+    get_app_config,
+    get_app_rules_config,
+    get_category_for_rule,
     get_config,
+    get_disabled_categories,
     get_disabled_rules,
+    get_enabled_categories,
     get_excluded_apps,
     get_fail_on_warning,
     get_rule_severity,
+    get_rule_severity_for_app,
+    get_rules_from_categories,
+    get_rules_in_category,
     get_severity_overrides,
     is_rule_disabled,
+    is_rule_disabled_by_category,
+    is_rule_enabled,
+    is_rule_enabled_for_app,
 )
 from django_safe_migrations.rules.base import Severity
 
@@ -223,3 +236,521 @@ class TestGetFailOnWarning:
             result = get_fail_on_warning()
 
             assert result is True
+
+
+class TestRuleCategories:
+    """Tests for rule category constants."""
+
+    def test_rule_categories_is_dict(self):
+        """Test RULE_CATEGORIES is a dictionary."""
+        assert isinstance(RULE_CATEGORIES, dict)
+
+    def test_all_categories_have_list_values(self):
+        """Test all category values are lists."""
+        for category, rules in RULE_CATEGORIES.items():
+            assert isinstance(rules, list), f"Category {category} value should be list"
+
+    def test_postgresql_category_contains_expected_rules(self):
+        """Test PostgreSQL category contains expected rules."""
+        pg_rules = RULE_CATEGORIES.get("postgresql", [])
+        # SM010 and SM011 are index-related PostgreSQL rules
+        assert "SM010" in pg_rules
+        assert "SM011" in pg_rules
+        assert "SM018" in pg_rules  # Concurrent operations
+
+    def test_destructive_category_exists(self):
+        """Test destructive category exists with expected rules."""
+        assert "destructive" in RULE_CATEGORIES
+        destructive_rules = RULE_CATEGORIES["destructive"]
+        assert "SM002" in destructive_rules  # RemoveField
+        assert "SM003" in destructive_rules  # DeleteModel
+
+
+class TestGetDisabledCategories:
+    """Tests for get_disabled_categories function."""
+
+    def test_returns_empty_list_by_default(self):
+        """Test returns empty list when no categories disabled."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = get_disabled_categories()
+
+            assert result == []
+
+    def test_returns_disabled_categories_from_settings(self):
+        """Test returns disabled categories from settings."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_CATEGORIES": ["reversibility", "informational"],
+            }
+
+            result = get_disabled_categories()
+
+            assert result == ["reversibility", "informational"]
+
+
+class TestGetEnabledCategories:
+    """Tests for get_enabled_categories function."""
+
+    def test_returns_empty_list_by_default(self):
+        """Test returns empty list (all enabled) by default."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = get_enabled_categories()
+
+            assert result == []
+
+    def test_returns_enabled_categories_from_settings(self):
+        """Test returns enabled categories from settings."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "ENABLED_CATEGORIES": ["high-risk", "destructive"],
+            }
+
+            result = get_enabled_categories()
+
+            assert result == ["high-risk", "destructive"]
+
+
+class TestGetRulesInCategory:
+    """Tests for get_rules_in_category function."""
+
+    def test_returns_rules_for_valid_category(self):
+        """Test returns rules for existing category."""
+        result = get_rules_in_category("postgresql")
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert "SM010" in result
+
+    def test_returns_empty_list_for_unknown_category(self):
+        """Test returns empty list for unknown category."""
+        result = get_rules_in_category("nonexistent_category")
+
+        assert result == []
+
+    def test_returns_expected_rules_for_indexes(self):
+        """Test indexes category contains expected rules."""
+        result = get_rules_in_category("indexes")
+
+        assert "SM010" in result  # UnsafeIndexCreation
+        assert "SM011" in result  # UnsafeUniqueConstraint
+        assert "SM018" in result  # ConcurrentInAtomic
+
+
+class TestGetAllCategories:
+    """Tests for get_all_categories function."""
+
+    def test_returns_all_category_names(self):
+        """Test returns all category names as list."""
+        result = get_all_categories()
+
+        assert isinstance(result, list)
+        assert "postgresql" in result
+        assert "indexes" in result
+        assert "destructive" in result
+        assert "high-risk" in result
+
+    def test_matches_rule_categories_keys(self):
+        """Test result matches RULE_CATEGORIES keys."""
+        result = get_all_categories()
+
+        assert set(result) == set(RULE_CATEGORIES.keys())
+
+
+class TestGetRulesFromCategories:
+    """Tests for get_rules_from_categories function."""
+
+    def test_returns_empty_set_for_empty_list(self):
+        """Test returns empty set for empty categories list."""
+        result = get_rules_from_categories([])
+
+        assert result == set()
+
+    def test_returns_rules_from_single_category(self):
+        """Test returns rules from single category."""
+        result = get_rules_from_categories(["indexes"])
+
+        assert isinstance(result, set)
+        assert "SM010" in result
+        assert "SM011" in result
+
+    def test_returns_union_of_multiple_categories(self):
+        """Test returns union of rules from multiple categories."""
+        result = get_rules_from_categories(["indexes", "destructive"])
+
+        # Should contain index rules
+        assert "SM010" in result
+        assert "SM011" in result
+        # Should also contain destructive rules
+        assert "SM002" in result
+        assert "SM003" in result
+
+    def test_deduplicates_rules(self):
+        """Test that rules appearing in multiple categories are deduplicated."""
+        # Get rules from overlapping categories
+        result = get_rules_from_categories(["postgresql", "indexes"])
+
+        # SM010 appears in both - should only appear once
+        rule_list = list(result)
+        assert rule_list.count("SM010") == 1
+
+
+class TestIsRuleDisabledByCategory:
+    """Tests for is_rule_disabled_by_category function."""
+
+    def test_returns_false_when_no_category_config(self):
+        """Test returns False when no category configuration."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = is_rule_disabled_by_category("SM001")
+
+            assert result is False
+
+    def test_returns_true_for_rule_in_disabled_category(self):
+        """Test returns True for rule in disabled category."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_CATEGORIES": ["indexes"],
+            }
+
+            # SM010 is in indexes category
+            result = is_rule_disabled_by_category("SM010")
+
+            assert result is True
+
+    def test_returns_false_for_rule_not_in_disabled_category(self):
+        """Test returns False for rule not in disabled category."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_CATEGORIES": ["indexes"],
+            }
+
+            # SM001 is not in indexes category
+            result = is_rule_disabled_by_category("SM001")
+
+            assert result is False
+
+    def test_whitelist_mode_disables_rules_not_in_enabled_categories(self):
+        """Test whitelist mode disables rules not in enabled categories."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "ENABLED_CATEGORIES": ["indexes"],
+            }
+
+            # SM001 is not in indexes category
+            result = is_rule_disabled_by_category("SM001")
+
+            assert result is True
+
+    def test_whitelist_mode_enables_rules_in_enabled_categories(self):
+        """Test whitelist mode enables rules in enabled categories."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "ENABLED_CATEGORIES": ["indexes"],
+            }
+
+            # SM010 is in indexes category
+            result = is_rule_disabled_by_category("SM010")
+
+            assert result is False
+
+
+class TestIsRuleEnabled:
+    """Tests for is_rule_enabled function."""
+
+    def test_returns_true_for_enabled_rule(self):
+        """Test returns True for rule that is enabled."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = is_rule_enabled("SM001")
+
+            assert result is True
+
+    def test_returns_false_for_individually_disabled_rule(self):
+        """Test returns False for rule in DISABLED_RULES."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_RULES": ["SM001"],
+            }
+
+            result = is_rule_enabled("SM001")
+
+            assert result is False
+
+    def test_returns_false_for_rule_disabled_by_category(self):
+        """Test returns False for rule disabled by category."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_CATEGORIES": ["indexes"],
+            }
+
+            # SM010 is in indexes category
+            result = is_rule_enabled("SM010")
+
+            assert result is False
+
+    def test_individual_disable_takes_precedence(self):
+        """Test individual disable overrides category enable."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_RULES": ["SM010"],
+                "ENABLED_CATEGORIES": ["indexes"],  # SM010 is in this
+            }
+
+            # Even though indexes is enabled, SM010 is individually disabled
+            result = is_rule_enabled("SM010")
+
+            assert result is False
+
+
+class TestGetCategoryForRule:
+    """Tests for get_category_for_rule function."""
+
+    def test_returns_categories_for_rule(self):
+        """Test returns all categories containing rule."""
+        result = get_category_for_rule("SM010")
+
+        assert isinstance(result, list)
+        assert "postgresql" in result
+        assert "indexes" in result
+
+    def test_returns_empty_list_for_unknown_rule(self):
+        """Test returns empty list for rule not in any category."""
+        result = get_category_for_rule("SM999")
+
+        assert result == []
+
+    def test_returns_multiple_categories_for_rule(self):
+        """Test returns multiple categories when rule belongs to many."""
+        result = get_category_for_rule("SM002")
+
+        # SM002 (RemoveField) should be in destructive and data-loss
+        assert "destructive" in result
+        assert "data-loss" in result
+
+
+# -----------------------------------------------------------------------------
+# Per-App Configuration Tests
+# -----------------------------------------------------------------------------
+
+
+class TestGetAppRulesConfig:
+    """Tests for get_app_rules_config function."""
+
+    def test_returns_empty_dict_by_default(self):
+        """Test returns empty dict when no APP_RULES configured."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = get_app_rules_config()
+
+            assert result == {}
+
+    def test_returns_app_rules_from_settings(self):
+        """Test returns APP_RULES from settings."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "myapp": {"DISABLED_RULES": ["SM001"]},
+                    "otherapp": {"ENABLED_CATEGORIES": ["indexes"]},
+                }
+            }
+
+            result = get_app_rules_config()
+
+            assert "myapp" in result
+            assert "otherapp" in result
+            assert result["myapp"]["DISABLED_RULES"] == ["SM001"]
+
+
+class TestGetAppConfig:
+    """Tests for get_app_config function."""
+
+    def test_returns_empty_dict_for_unconfigured_app(self):
+        """Test returns empty dict for app not in APP_RULES."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "myapp": {"DISABLED_RULES": ["SM001"]},
+                }
+            }
+
+            result = get_app_config("unconfigured_app")
+
+            assert result == {}
+
+    def test_returns_config_for_configured_app(self):
+        """Test returns config for app in APP_RULES."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "myapp": {
+                        "DISABLED_RULES": ["SM001", "SM002"],
+                        "RULE_SEVERITY": {"SM003": "INFO"},
+                    },
+                }
+            }
+
+            result = get_app_config("myapp")
+
+            assert result["DISABLED_RULES"] == ["SM001", "SM002"]
+            assert result["RULE_SEVERITY"] == {"SM003": "INFO"}
+
+
+class TestIsRuleEnabledForApp:
+    """Tests for is_rule_enabled_for_app function."""
+
+    def test_returns_global_result_when_no_app(self):
+        """Test falls back to global config when app_label is None."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_RULES": ["SM001"],
+            }
+
+            result = is_rule_enabled_for_app("SM001", None)
+
+            assert result is False
+
+    def test_returns_global_result_for_unconfigured_app(self):
+        """Test falls back to global config for unconfigured app."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_RULES": ["SM001"],
+                "APP_RULES": {},
+            }
+
+            result = is_rule_enabled_for_app("SM001", "unconfigured_app")
+
+            assert result is False
+
+    def test_app_disabled_rules_take_precedence(self):
+        """Test app-specific DISABLED_RULES disables rule."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "legacy_app": {"DISABLED_RULES": ["SM001", "SM002"]},
+                }
+            }
+
+            # SM001 disabled for legacy_app
+            assert is_rule_enabled_for_app("SM001", "legacy_app") is False
+            # SM003 not disabled for legacy_app
+            assert is_rule_enabled_for_app("SM003", "legacy_app") is True
+
+    def test_app_enabled_categories_whitelist(self):
+        """Test app-specific ENABLED_CATEGORIES creates whitelist."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "strict_app": {"ENABLED_CATEGORIES": ["indexes"]},
+                }
+            }
+
+            # SM010 is in indexes category - should be enabled
+            assert is_rule_enabled_for_app("SM010", "strict_app") is True
+            # SM001 is not in indexes category - should be disabled
+            assert is_rule_enabled_for_app("SM001", "strict_app") is False
+
+    def test_app_disabled_categories(self):
+        """Test app-specific DISABLED_CATEGORIES disables rules."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "relaxed_app": {"DISABLED_CATEGORIES": ["indexes"]},
+                }
+            }
+
+            # SM010 is in indexes category - should be disabled
+            assert is_rule_enabled_for_app("SM010", "relaxed_app") is False
+            # SM001 is not in indexes category - should be enabled
+            assert is_rule_enabled_for_app("SM001", "relaxed_app") is True
+
+    def test_global_disabled_still_applies(self):
+        """Test global DISABLED_RULES still applies even with app config."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "DISABLED_RULES": ["SM005"],  # Globally disabled
+                "APP_RULES": {
+                    "myapp": {"DISABLED_RULES": ["SM001"]},  # App-specific disable
+                },
+            }
+
+            # SM005 is globally disabled
+            assert is_rule_enabled_for_app("SM005", "myapp") is False
+            # SM001 is app-specifically disabled
+            assert is_rule_enabled_for_app("SM001", "myapp") is False
+            # SM002 is not disabled
+            assert is_rule_enabled_for_app("SM002", "myapp") is True
+
+
+class TestGetRuleSeverityForApp:
+    """Tests for get_rule_severity_for_app function."""
+
+    def test_returns_default_when_no_override(self):
+        """Test returns default severity when no override."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {}
+
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, "myapp")
+
+            assert result == Severity.ERROR
+
+    def test_returns_global_override(self):
+        """Test returns global severity override."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "RULE_SEVERITY": {"SM001": "INFO"},
+            }
+
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, "myapp")
+
+            assert result == Severity.INFO
+
+    def test_app_override_takes_precedence(self):
+        """Test app-specific severity takes precedence over global."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "RULE_SEVERITY": {"SM001": "WARNING"},  # Global override
+                "APP_RULES": {
+                    "legacy_app": {
+                        "RULE_SEVERITY": {"SM001": "INFO"},  # App override
+                    }
+                },
+            }
+
+            # App override should take precedence
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, "legacy_app")
+            assert result == Severity.INFO
+
+            # Other apps use global
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, "other_app")
+            assert result == Severity.WARNING
+
+    def test_handles_uppercase_severity_in_app_config(self):
+        """Test handles uppercase severity strings in app config."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "APP_RULES": {
+                    "myapp": {"RULE_SEVERITY": {"SM001": "WARNING"}},
+                }
+            }
+
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, "myapp")
+
+            assert result == Severity.WARNING
+
+    def test_returns_global_when_no_app(self):
+        """Test returns global severity when app_label is None."""
+        with patch("django_safe_migrations.conf.settings") as mock_settings:
+            mock_settings.SAFE_MIGRATIONS = {
+                "RULE_SEVERITY": {"SM001": "INFO"},
+            }
+
+            result = get_rule_severity_for_app("SM001", Severity.ERROR, None)
+
+            assert result == Severity.INFO


### PR DESCRIPTION
New Features:
- SM018: Detect concurrent index operations in atomic migrations
- SM019: Detect SQL reserved keywords as column names
- Rule categories for bulk enable/disable (DISABLED_CATEGORIES, ENABLED_CATEGORIES)
- Per-app rule configuration via APP_RULES setting
- Debug logging throughout the analyzer

Improvements:
- AST-based line number detection for more accurate results
- Smarter AlterField detection (SM004) to reduce false positives

Documentation:
- Updated configuration guide with category and per-app settings
- Added rule documentation for SM018 and SM019

Tests:
- Added test migrations for SM018 and SM019
- Added integration tests for category and per-app configuration
- Extended unit test coverage for new features