### PR TITLE
Fix CommandError when AppConfig.label differs from directory name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `--diff` misidentifying app labels when `AppConfig.label` differs from
+  the package directory name. The app label is now resolved via Django's app
+  registry (`AppConfig.path`) instead of assuming directory name equals label.
+
 ## [0.6.0] - 2026-03-24
 
 ### Added

--- a/django_safe_migrations/diff.py
+++ b/django_safe_migrations/diff.py
@@ -16,6 +16,8 @@ import os
 import subprocess  # nosec B404
 from pathlib import Path
 
+from django.apps import apps as django_apps
+
 logger = logging.getLogger("django_safe_migrations")
 
 
@@ -82,6 +84,9 @@ def get_changed_apps_and_migrations(
     """Get (app_label, migration_name) pairs for changed migrations.
 
     Parses the file paths to extract app labels and migration names.
+    The app label is resolved via Django's app registry so that apps
+    whose ``AppConfig.label`` differs from their package directory name
+    are handled correctly.
 
     Args:
         base_ref: Git ref to diff against.
@@ -102,8 +107,13 @@ def get_changed_apps_and_migrations(
         migrations_dir = path.parent  # .../app_name/migrations/
         app_dir = migrations_dir.parent  # .../app_name/
 
-        # The app label is typically the directory name
+        # Prefer the app registry label in case AppConfig.label differs from
+        # the package directory name (e.g. namespaced apps or custom labels).
         app_label = app_dir.name
+        for app_config in django_apps.get_app_configs():
+            if Path(app_config.path) == app_dir:
+                app_label = app_config.label
+                break
 
         result.append((app_label, migration_name))
 

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -290,6 +290,50 @@ class TestGetChangedAppsAndMigrations:
 
         mock_fn.assert_called_once_with("feature-branch")
 
+    def test_resolves_custom_app_label(self, tmp_path):
+        """Test that a custom AppConfig.label is used instead of the directory name."""
+        app_dir = tmp_path / "billing_app"
+        migrations_dir = app_dir / "migrations"
+        migrations_dir.mkdir(parents=True)
+
+        changed_files = [str(migrations_dir / "0001_initial.py")]
+
+        mock_app_config = MagicMock()
+        mock_app_config.path = str(app_dir)
+        mock_app_config.label = "billing"  # label differs from dir name "billing_app"
+
+        with (
+            patch(
+                "django_safe_migrations.diff.get_changed_migration_files",
+                return_value=changed_files,
+            ),
+            patch(
+                "django_safe_migrations.diff.django_apps.get_app_configs",
+                return_value=[mock_app_config],
+            ),
+        ):
+            result = get_changed_apps_and_migrations("main")
+
+        assert result == [("billing", "0001_initial")]
+
+    def test_falls_back_to_dir_name_when_app_not_registered(self):
+        """Test that the directory name is used when no app registry match exists."""
+        changed_files = ["/project/unregistered_app/migrations/0001_initial.py"]
+
+        with (
+            patch(
+                "django_safe_migrations.diff.get_changed_migration_files",
+                return_value=changed_files,
+            ),
+            patch(
+                "django_safe_migrations.diff.django_apps.get_app_configs",
+                return_value=[],
+            ),
+        ):
+            result = get_changed_apps_and_migrations("main")
+
+        assert result == [("unregistered_app", "0001_initial")]
+
     def test_multiple_migrations_same_app(self):
         """Test handling multiple migrations from the same app."""
         changed_files = [


### PR DESCRIPTION
## Fix `CommandError` when `AppConfig.label` differs from directory name

### Problem

When using `--diff`, `check_migrations` would raise a `CommandError` like:

```
CommandError: Migration '0006_problem_new_fake_field' not found for app 'questions'.
```

This happened when an app's `AppConfig.label` was set to something different from its package directory name. For example:

```python
class QuestionsConfig(AppConfig):
    name = "project.xx.xx.problems.questions"
    label = "problems"
    verbose_name = "Problems"
```

Here the directory name is `questions`, but Django registers the app under the label `problems`. When `--diff` detected changed migration files, it extracted the app label directly from the directory name — so it looked up `questions` in the migration loader, which has no record of that label, causing the error.

### Fix

`get_changed_apps_and_migrations` in `diff.py` now resolves the app label via Django's app registry. It matches the migration file's parent directory against registered `AppConfig.path` values and uses `AppConfig.label` when a match is found, falling back to the directory name for any app not in the registry.

### Tests

- Added `test_resolves_custom_app_label` — verifies the registry label is used when `AppConfig.label` differs from the directory name.
- Added `test_falls_back_to_dir_name_when_app_not_registered` — verifies the directory name fallback for apps not in the registry.
- Ran tests + pre-commit checks.