### PR TITLE
fix: v0.6.1 hotfix batch (version desync, SDS analysis, exclusions, perf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+*.sqlite3
+test_db.sqlite3
 
 # Flask stuff:
 instance/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-03
+
+### Fixed
+
+- Fix version desync: `__version__` was stuck at `0.5.2` while the package
+  shipped as `0.6.0`, which mislabeled the SARIF reporter's tool driver
+  version in GitHub Code Scanning. Bumped to `0.6.1` and added a test that
+  asserts `__version__` matches the `pyproject.toml` version.
+- Analyze operations wrapped in `SeparateDatabaseAndState`. Previously, unsafe
+  database operations hidden inside the wrapper (e.g. a NOT NULL `AddField`, a
+  non-concurrent `AddIndex`, an `AddConstraint`) were silently skipped.
+- `--new-only` now honors `EXCLUDED_APPS` and the default Django built-in app
+  exclusion, consistent with a full run. Previously it scanned every app,
+  including `admin`/`auth`/etc.
+- Settings-level `FAIL_ON_WARNING` is now honored by both the management
+  command and the standalone CLI exit codes (previously only the
+  `--fail-on-warning` flag had any effect).
+- `--diff` no longer aborts the entire run when a changed file does not resolve
+  to a known migration (custom `AppConfig.label`, an app not in
+  `INSTALLED_APPS`, or a non-migration `.py` under a `migrations/` directory).
+  Such files are skipped with a warning. The standalone CLI now also reports
+  `DiffError` cleanly (exit 2) instead of an uncaught traceback.
+
+### Security
+
+- `--diff BASE_REF` now rejects refs beginning with `-`, preventing git
+  argument injection (e.g. `--output=<file>`, which could make git write the
+  diff to an arbitrary path).
+
+### Performance
+
+- Resolve the old-field state for `AlterField` once per operation instead of
+  once per rule, and build the `MigrationLoader` once per analysis run and
+  reuse it instead of rebuilding it for every app and every `AlterField`. This
+  removes an O(rules × migrations) blow-up in field-state resolution.
+
 ## [0.6.0] - 2026-03-24
 
 ### Added

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.5.2"
+__version__ = "0.6.1"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -105,6 +105,7 @@ class MigrationAnalyzer:
         migration: Migration,
         app_label: Optional[str] = None,
         migration_name: Optional[str] = None,
+        loader: Optional[Any] = None,
     ) -> list[Issue]:
         """Analyze a single migration for issues.
 
@@ -112,6 +113,9 @@ class MigrationAnalyzer:
             migration: The Django migration to analyze.
             app_label: Optional app label override.
             migration_name: Optional migration name override.
+            loader: Optional pre-built ``MigrationLoader`` reused for old-field
+                    state resolution. Avoids rebuilding the loader (which reads
+                    every migration on disk) for each operation.
 
         Returns:
             A list of Issue objects found in the migration.
@@ -136,91 +140,41 @@ class MigrationAnalyzer:
         # Pre-parse suppression comments for efficiency
         suppressions = get_suppressions_for_migration(migration)
 
+        from django.db import migrations as mig_module
+
         for idx, operation in enumerate(operations):
             # Get operation line number for suppression checking
             operation_line = get_operation_line_number(migration, idx)
 
-            for rule in self.rules:
-                # Skip disabled rules (individual, category-based, or per-app)
-                if not self._is_rule_enabled(rule.rule_id, app_label):
-                    logger.debug(
-                        "Skipping rule %s: disabled for app %s",
-                        rule.rule_id,
-                        app_label,
-                    )
-                    continue
+            self._check_operation(
+                operation=operation,
+                operation_index=idx,
+                operation_line=operation_line,
+                migration=migration,
+                app_label=app_label,
+                migration_name=migration_name,
+                file_path=file_path,
+                suppressions=suppressions,
+                loader=loader,
+                issues=issues,
+            )
 
-                # Skip rules that don't apply to this database
-                if not rule.applies_to_db(self.db_vendor):
-                    logger.debug(
-                        "Skipping rule %s: does not apply to %s",
-                        rule.rule_id,
-                        self.db_vendor,
-                    )
-                    continue
-
-                # Check for inline suppression comments
-                if file_path and operation_line:
-                    if is_operation_suppressed(
-                        file_path, operation_line, rule.rule_id, suppressions
-                    ):
-                        logger.debug(
-                            "Skipping rule %s: suppressed at line %d",
-                            rule.rule_id,
-                            operation_line,
-                        )
-                        continue
-
-                # Resolve old field state for AlterField operations
-                rule_kwargs: dict[str, object] = {
-                    "db_vendor": self.db_vendor,
-                }
-                from django.db import migrations as mig_module
-
-                if (
-                    isinstance(operation, mig_module.AlterField)
-                    and app_label
-                    and migration_name
-                ):
-                    old_field = resolve_field_before_operation(
+            # Recurse into SeparateDatabaseAndState so unsafe database
+            # operations hidden inside the wrapper are still analyzed.
+            if isinstance(operation, mig_module.SeparateDatabaseAndState):
+                for db_op in operation.database_operations or []:
+                    self._check_operation(
+                        operation=db_op,
+                        operation_index=idx,
+                        operation_line=operation_line,
+                        migration=migration,
                         app_label=app_label,
                         migration_name=migration_name,
-                        operation_index=idx,
-                        model_name=operation.model_name,
-                        field_name=operation.name,
+                        file_path=file_path,
+                        suppressions=suppressions,
+                        loader=loader,
+                        issues=issues,
                     )
-                    rule_kwargs["old_field"] = old_field
-
-                issue = rule.check(
-                    operation=operation,
-                    migration=migration,
-                    **rule_kwargs,
-                )
-
-                if issue:
-                    # Apply severity override from settings (per-app or global)
-                    issue.severity = get_rule_severity_for_app(
-                        issue.rule_id, issue.severity, app_label
-                    )
-
-                    # Enrich issue with context
-                    if issue.file_path is None:
-                        issue.file_path = file_path
-                    if issue.line_number is None:
-                        issue.line_number = operation_line
-                    if issue.app_label is None:
-                        issue.app_label = app_label
-                    if issue.migration_name is None:
-                        issue.migration_name = migration_name
-
-                    logger.debug(
-                        "Found issue: %s in %s.%s at line %s",
-                        issue.rule_id,
-                        app_label,
-                        migration_name,
-                        operation_line,
-                    )
-                    issues.append(issue)
 
         logger.debug(
             "Migration %s.%s analysis complete: %d issues found",
@@ -230,11 +184,104 @@ class MigrationAnalyzer:
         )
         return issues
 
-    def analyze_app(self, app_label: str) -> list[Issue]:
+    def _check_operation(
+        self,
+        operation: Any,
+        operation_index: int,
+        operation_line: Optional[int],
+        migration: Migration,
+        app_label: Optional[str],
+        migration_name: Optional[str],
+        file_path: Optional[str],
+        suppressions: Any,
+        loader: Any,
+        issues: list[Issue],
+    ) -> None:
+        """Run all enabled rules against a single operation.
+
+        The old-field state for ``AlterField`` operations is resolved once
+        per operation (not once per rule), avoiding a redundant rebuild of
+        the migration state for every rule. Matching issues are appended to
+        ``issues`` in place.
+        """
+        from django.db import migrations as mig_module
+
+        # Resolve old field state once per operation (shared by all rules).
+        is_alter_field = (
+            isinstance(operation, mig_module.AlterField)
+            and bool(app_label)
+            and bool(migration_name)
+        )
+        old_field = None
+        if is_alter_field:
+            old_field = resolve_field_before_operation(
+                app_label=app_label,  # type: ignore[arg-type]
+                migration_name=migration_name,  # type: ignore[arg-type]
+                operation_index=operation_index,
+                model_name=operation.model_name,
+                field_name=operation.name,
+                loader=loader,
+            )
+
+        for rule in self.rules:
+            # Skip disabled rules (individual, category-based, or per-app)
+            if not self._is_rule_enabled(rule.rule_id, app_label):
+                continue
+
+            # Skip rules that don't apply to this database
+            if not rule.applies_to_db(self.db_vendor):
+                continue
+
+            # Check for inline suppression comments
+            if file_path and operation_line:
+                if is_operation_suppressed(
+                    file_path, operation_line, rule.rule_id, suppressions
+                ):
+                    continue
+
+            rule_kwargs: dict[str, object] = {"db_vendor": self.db_vendor}
+            if is_alter_field:
+                rule_kwargs["old_field"] = old_field
+
+            issue = rule.check(
+                operation=operation,
+                migration=migration,
+                **rule_kwargs,
+            )
+            if not issue:
+                continue
+
+            # Apply severity override from settings (per-app or global)
+            issue.severity = get_rule_severity_for_app(
+                issue.rule_id, issue.severity, app_label
+            )
+
+            # Enrich issue with context
+            if issue.file_path is None:
+                issue.file_path = file_path
+            if issue.line_number is None:
+                issue.line_number = operation_line
+            if issue.app_label is None:
+                issue.app_label = app_label
+            if issue.migration_name is None:
+                issue.migration_name = migration_name
+
+            logger.debug(
+                "Found issue: %s in %s.%s at line %s",
+                issue.rule_id,
+                app_label,
+                migration_name,
+                operation_line,
+            )
+            issues.append(issue)
+
+    def analyze_app(self, app_label: str, loader: Any = None) -> list[Issue]:
         """Analyze all migrations for a Django app.
 
         Args:
             app_label: The app label (e.g., 'myapp').
+            loader: Optional pre-built ``MigrationLoader`` to reuse instead of
+                    constructing a new one (which re-reads every migration).
 
         Returns:
             A list of Issue objects found in the app's migrations.
@@ -242,7 +289,8 @@ class MigrationAnalyzer:
         from django.db.migrations.loader import MigrationLoader
 
         issues: list[Issue] = []
-        loader = MigrationLoader(None, ignore_no_migrations=True)
+        if loader is None:
+            loader = MigrationLoader(None, ignore_no_migrations=True)
 
         # Get all migrations for this app from disk_migrations.
         # Use disk_migrations values directly instead of get_migration()
@@ -269,6 +317,7 @@ class MigrationAnalyzer:
                     migration=migration,
                     app_label=app_label,
                     migration_name=name,
+                    loader=loader,
                 )
             )
 
@@ -317,7 +366,7 @@ class MigrationAnalyzer:
             if app_label in exclude_apps:
                 logger.debug("Skipping excluded app: %s", app_label)
                 continue
-            issues.extend(self.analyze_app(app_label))
+            issues.extend(self.analyze_app(app_label, loader=loader))
 
         logger.info("Analysis complete: %d total issues found", len(issues))
         if self.verbose:
@@ -327,6 +376,7 @@ class MigrationAnalyzer:
     def analyze_new_migrations(
         self,
         app_label: Optional[str] = None,
+        exclude_apps: Optional[list[str]] = None,
     ) -> list[Issue]:
         """Analyze only unapplied (new) migrations.
 
@@ -335,6 +385,9 @@ class MigrationAnalyzer:
 
         Args:
             app_label: Optional app label to filter by.
+            exclude_apps: List of app labels to exclude (e.g., Django's
+                          built-in apps). If None, uses
+                          SAFE_MIGRATIONS["EXCLUDED_APPS"] from settings.
 
         Returns:
             A list of Issue objects found in unapplied migrations.
@@ -342,6 +395,9 @@ class MigrationAnalyzer:
         from django.db import connection
         from django.db.migrations.loader import MigrationLoader
         from django.db.migrations.recorder import MigrationRecorder
+
+        if exclude_apps is None:
+            exclude_apps = get_excluded_apps()
 
         issues: list[Issue] = []
         loader = MigrationLoader(connection)
@@ -351,6 +407,10 @@ class MigrationAnalyzer:
         unapplied_count = 0
         for key in loader.disk_migrations.keys():
             app, name = key
+            # Skip excluded apps (Django built-ins, user-configured)
+            if app in exclude_apps:
+                continue
+
             # Skip if already applied
             if (app, name) in applied:
                 continue
@@ -368,6 +428,7 @@ class MigrationAnalyzer:
                     migration=migration,
                     app_label=app,
                     migration_name=name,
+                    loader=loader,
                 )
             )
 

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -231,7 +231,7 @@ Documentation: https://django-safe-migrations.readthedocs.io/
 
     # Import after Django setup
     from django_safe_migrations.analyzer import MigrationAnalyzer
-    from django_safe_migrations.conf import log_config_warnings
+    from django_safe_migrations.conf import get_fail_on_warning, log_config_warnings
     from django_safe_migrations.reporters import get_reporter
     from django_safe_migrations.rules.base import Issue, Severity
 
@@ -266,9 +266,16 @@ Documentation: https://django-safe-migrations.readthedocs.io/
 
     if args.diff is not None:
         # Diff mode — only check changed migrations
-        from django_safe_migrations.diff import get_changed_apps_and_migrations
+        from django_safe_migrations.diff import (
+            DiffError,
+            get_changed_apps_and_migrations,
+        )
 
-        changed = get_changed_apps_and_migrations(args.diff)
+        try:
+            changed = get_changed_apps_and_migrations(args.diff)
+        except DiffError as e:
+            print(str(e), file=sys.stderr)
+            return 2
         if args.verbose:
             print(
                 f"Diff mode: checking {len(changed)} changed migration(s)",
@@ -284,9 +291,13 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     elif args.new_only:
         if args.app_labels:
             for app_label in args.app_labels:
-                issues.extend(analyzer.analyze_new_migrations(app_label))
+                issues.extend(
+                    analyzer.analyze_new_migrations(
+                        app_label, exclude_apps=exclude_apps
+                    )
+                )
         else:
-            issues.extend(analyzer.analyze_new_migrations())
+            issues.extend(analyzer.analyze_new_migrations(exclude_apps=exclude_apps))
     elif args.app_labels:
         for app_label in args.app_labels:
             if app_label not in exclude_apps:
@@ -328,13 +339,14 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     # Generate report
     reporter.report(issues)
 
-    # Determine exit code
+    # Determine exit code (CLI flag OR settings-level FAIL_ON_WARNING)
+    fail_on_warning = args.fail_on_warning or get_fail_on_warning()
     errors = [i for i in issues if i.severity == Severity.ERROR]
     warnings = [i for i in issues if i.severity == Severity.WARNING]
 
     if errors:
         return 1
-    elif warnings and args.fail_on_warning:
+    elif warnings and fail_on_warning:
         return 1
 
     return 0

--- a/django_safe_migrations/diff.py
+++ b/django_safe_migrations/diff.py
@@ -40,6 +40,11 @@ def get_changed_migration_files(base_ref: str = "main") -> list[str]:
     Raises:
         DiffError: If the git ref does not exist or git command fails.
     """
+    # Reject refs that could be interpreted as git options (argument
+    # injection, e.g. ``--output=<file>`` which would make git write to an
+    # arbitrary path). A leading dash is never valid in a branch/tag/commit.
+    if base_ref.startswith("-"):
+        raise DiffError(f"Invalid base ref '{base_ref}': refs may not start with '-'.")
     try:
         result = subprocess.run(  # nosec B603 B607
             ["git", "diff", "--name-only", "--diff-filter=ACMR", base_ref],

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -9,7 +9,11 @@ from typing import IO, Any
 from django.core.management.base import BaseCommand, CommandParser
 
 from django_safe_migrations.analyzer import MigrationAnalyzer
-from django_safe_migrations.conf import get_category_for_rule, log_config_warnings
+from django_safe_migrations.conf import (
+    get_category_for_rule,
+    get_fail_on_warning,
+    log_config_warnings,
+)
 from django_safe_migrations.reporters import get_reporter
 from django_safe_migrations.rules import ALL_RULES, _load_extra_rules
 from django_safe_migrations.rules.base import Issue, Severity
@@ -226,7 +230,8 @@ class Command(BaseCommand):
 
         app_labels = options["app_labels"]
         output_file = options["output"]
-        fail_on_warning = options["fail_on_warning"]
+        # CLI flag OR the settings-level FAIL_ON_WARNING setting
+        fail_on_warning = options["fail_on_warning"] or get_fail_on_warning()
         new_only = options["new_only"]
         show_suggestions = not options["no_suggestions"]
         cli_exclude_apps = options["exclude_apps"]
@@ -258,6 +263,8 @@ class Command(BaseCommand):
 
         diff_ref = options.get("diff")
         if diff_ref is not None:
+            from django.core.management.base import CommandError
+
             from django_safe_migrations.diff import (
                 DiffError,
                 get_changed_apps_and_migrations,
@@ -274,21 +281,39 @@ class Command(BaseCommand):
                     f"Diff mode: checking {len(changed)} changed migration(s)"
                 )
             for app_label, migration_name in changed:
-                if app_label not in exclude_apps:
-                    app_issues = analyzer.analyze_migration(
-                        migration=self._load_migration(
-                            analyzer, app_label, migration_name
-                        ),
+                if app_label in exclude_apps:
+                    continue
+                # A changed file may not resolve to a known migration (e.g.
+                # an app whose label differs from its directory, an app not
+                # in INSTALLED_APPS, or a non-migration .py under a
+                # ``migrations/`` directory). Warn and skip rather than
+                # aborting the entire run.
+                try:
+                    migration = self._load_migration(
+                        analyzer, app_label, migration_name
+                    )
+                except CommandError as e:
+                    self.stderr.write(self.style.WARNING(f"Skipping: {e}"))
+                    continue
+                issues.extend(
+                    analyzer.analyze_migration(
+                        migration=migration,
                         app_label=app_label,
                         migration_name=migration_name,
                     )
-                    issues.extend(app_issues)
+                )
         elif new_only:
             if app_labels:
                 for app_label in app_labels:
-                    issues.extend(analyzer.analyze_new_migrations(app_label))
+                    issues.extend(
+                        analyzer.analyze_new_migrations(
+                            app_label, exclude_apps=exclude_apps
+                        )
+                    )
             else:
-                issues.extend(analyzer.analyze_new_migrations())
+                issues.extend(
+                    analyzer.analyze_new_migrations(exclude_apps=exclude_apps)
+                )
         elif app_labels:
             for app_label in app_labels:
                 if app_label not in exclude_apps:

--- a/django_safe_migrations/utils.py
+++ b/django_safe_migrations/utils.py
@@ -333,6 +333,7 @@ def resolve_field_before_operation(
     operation_index: int,
     model_name: str,
     field_name: str,
+    loader: Any = None,
 ) -> Any:
     """Resolve the field definition before an AlterField operation.
 
@@ -346,6 +347,10 @@ def resolve_field_before_operation(
         operation_index: The index of the operation within the migration.
         model_name: The model name (lowercase).
         field_name: The field name.
+        loader: Optional pre-built ``MigrationLoader`` to reuse. When omitted
+                a new loader is constructed, which re-reads every migration on
+                disk; callers analysing many operations should pass a shared
+                loader to avoid that cost.
 
     Returns:
         The old field instance, or None if it cannot be resolved.
@@ -353,7 +358,8 @@ def resolve_field_before_operation(
     try:
         from django.db.migrations.loader import MigrationLoader
 
-        loader = MigrationLoader(None, ignore_no_migrations=True)
+        if loader is None:
+            loader = MigrationLoader(None, ignore_no_migrations=True)
         migration_key = (app_label, migration_name)
 
         if migration_key not in loader.disk_migrations:

--- a/docs/roadmap/v0.6.0.md
+++ b/docs/roadmap/v0.6.0.md
@@ -1,7 +1,12 @@
 # v0.6.0 Roadmap
 
-This document tracks planned features, improvements, and implementation details
-for v0.6.0.
+This document tracks planned features, improvements, and implementation details.
+
+> **Status (2026-06): not yet delivered.** The released v0.6.0 (2026-03-24) and
+> the v0.6.1 maintenance release were bug-fix/stability releases — none of the
+> new rules (SM037–SM057) or features below have shipped yet. They remain
+> **planned** and are deferred to a future release (targeting v0.7.0). The
+> current rule set is SM001–SM036. See `CHANGELOG.md` for what actually shipped.
 
 ## Theme: Django 5.x/6.0 Awareness, Zero-Downtime Patterns & DX
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.6.0"
+version = "0.6.1"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -219,6 +219,65 @@ class TestCommandOptions:
         # Safe app should pass without --fail-on-warning
         assert exit_code == 0
 
+    @override_settings(SAFE_MIGRATIONS={"FAIL_ON_WARNING": True})
+    def test_fail_on_warning_setting_exits_1(self):
+        """Settings-level FAIL_ON_WARNING (no CLI flag) causes exit 1 on warnings."""
+        from unittest.mock import patch
+
+        from django_safe_migrations.rules.base import Issue, Severity
+
+        warning = Issue(
+            rule_id="SM999",
+            severity=Severity.WARNING,
+            operation="op",
+            message="a warning",
+        )
+        out = StringIO()
+        with patch(
+            "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+            return_value=[warning],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                call_command("check_migrations", stdout=out)
+        assert exc.value.code == 1
+
+    def test_warning_only_exits_0_without_fail_on_warning(self):
+        """Warnings alone do not fail when neither flag nor setting is set."""
+        from unittest.mock import patch
+
+        from django_safe_migrations.rules.base import Issue, Severity
+
+        warning = Issue(
+            rule_id="SM999",
+            severity=Severity.WARNING,
+            operation="op",
+            message="a warning",
+        )
+        out = StringIO()
+        with patch(
+            "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+            return_value=[warning],
+        ):
+            try:
+                call_command("check_migrations", stdout=out)
+                exit_code = 0
+            except SystemExit as e:
+                exit_code = e.code
+        assert exit_code == 0
+
+    def test_diff_skips_unresolvable_migration(self):
+        """--diff warns and continues on a file that resolves to no migration."""
+        from unittest.mock import patch
+
+        out, err = StringIO(), StringIO()
+        with patch(
+            "django_safe_migrations.diff.get_changed_apps_and_migrations",
+            return_value=[("nonexistent_app", "0001_bogus")],
+        ):
+            # Must NOT raise CommandError; with no resolvable issues it exits 0.
+            call_command("check_migrations", diff="main", stdout=out, stderr=err)
+        assert "Skipping" in err.getvalue()
+
     def test_exclude_apps_removes_detection(self):
         """Test --exclude-apps properly excludes apps from analysis."""
         out = StringIO()

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -502,6 +502,85 @@ class TestAnalyzeNewMigrations:
             issues = analyzer.analyze_new_migrations()
             assert issues == []
 
+    def test_analyze_new_migrations_excludes_apps(self, mock_migration_factory):
+        """Test that analyze_new_migrations honors the exclude_apps list."""
+        from unittest.mock import MagicMock, patch
+
+        unsafe = [
+            migrations.AddField(
+                model_name="user",
+                name="email",
+                field=models.CharField(max_length=255),  # NOT NULL, no default
+            )
+        ]
+        disk = {
+            ("testapp", "0001_initial"): mock_migration_factory(
+                unsafe, app_label="testapp", name="0001_initial"
+            ),
+            ("admin", "0001_initial"): mock_migration_factory(
+                unsafe, app_label="admin", name="0001_initial"
+            ),
+        }
+        mock_loader = self._make_mock_loader(disk)
+        mock_recorder = MagicMock()
+        mock_recorder.applied_migrations.return_value = set()
+
+        with (
+            patch(
+                "django.db.migrations.loader.MigrationLoader",
+                return_value=mock_loader,
+            ),
+            patch(
+                "django.db.migrations.recorder.MigrationRecorder",
+                return_value=mock_recorder,
+            ),
+        ):
+            analyzer = MigrationAnalyzer(db_vendor="postgresql")
+            issues = analyzer.analyze_new_migrations(exclude_apps=["admin"])
+
+        analyzed_apps = {issue.app_label for issue in issues}
+        assert "admin" not in analyzed_apps
+        assert "testapp" in analyzed_apps
+
+
+class TestSeparateDatabaseAndState:
+    """Operations wrapped in SeparateDatabaseAndState must still be analyzed."""
+
+    def test_wrapped_database_operation_is_analyzed(self, mock_migration_factory):
+        """An unsafe op inside database_operations is detected (was a blind spot)."""
+        unsafe = migrations.AddField(
+            model_name="user",
+            name="email",
+            field=models.CharField(max_length=255),  # NOT NULL, no default
+        )
+        sds = migrations.SeparateDatabaseAndState(
+            database_operations=[unsafe],
+            state_operations=[],
+        )
+        migration = mock_migration_factory([sds])
+
+        analyzer = MigrationAnalyzer(db_vendor="postgresql")
+        issues = analyzer.analyze_migration(
+            migration, app_label="testapp", migration_name="0001_test"
+        )
+
+        assert "SM001" in {issue.rule_id for issue in issues}
+
+    def test_empty_separate_database_and_state_is_safe(self, mock_migration_factory):
+        """A SeparateDatabaseAndState with no database_operations yields nothing."""
+        sds = migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[],
+        )
+        migration = mock_migration_factory([sds])
+
+        analyzer = MigrationAnalyzer(db_vendor="postgresql")
+        issues = analyzer.analyze_migration(
+            migration, app_label="testapp", migration_name="0001_test"
+        )
+
+        assert issues == []
+
 
 class TestSquashedMigrations:
     """Tests for handling squashed/replaced migrations without KeyError."""

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from django_safe_migrations.diff import (
+    DiffError,
     _find_git_root,
     get_changed_apps_and_migrations,
     get_changed_migration_files,
@@ -169,6 +170,17 @@ class TestGetChangedMigrationFiles:
         with patch("django_safe_migrations.diff.subprocess.run", side_effect=mock_run):
             with pytest.raises(DiffError, match="git is not installed"):
                 get_changed_migration_files("main")
+
+    def test_rejects_ref_starting_with_dash(self):
+        """A base ref starting with '-' is rejected before any git call.
+
+        Guards against argument injection (e.g. ``--output=<file>``) where a
+        crafted ref would be interpreted as a git option.
+        """
+        with patch("django_safe_migrations.diff.subprocess.run") as mock_run:
+            with pytest.raises(DiffError, match="may not start with"):
+                get_changed_migration_files("--output=/tmp/evil")
+        mock_run.assert_not_called()
 
     def test_uses_custom_base_ref(self, tmp_path):
         """Test that the base_ref parameter is passed to git diff."""

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,38 @@
+"""Tests that the package version stays consistent across sources.
+
+Guards against the version desync where pyproject.toml and
+``django_safe_migrations.__version__`` drift apart (e.g. 0.6.0 vs 0.5.2),
+which silently mislabels the SARIF reporter's tool driver version.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import django_safe_migrations
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _pyproject_version() -> str:
+    """Read the project version from pyproject.toml.
+
+    Uses tomllib on Python 3.11+ and falls back to a simple regex on
+    older interpreters so the test runs across the full support matrix.
+    """
+    try:
+        import tomllib  # type: ignore[import-not-found]
+
+        with PYPROJECT.open("rb") as fh:
+            return str(tomllib.load(fh)["project"]["version"])
+    except ModuleNotFoundError:
+        text = PYPROJECT.read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        assert match, "Could not find version in pyproject.toml"
+        return match.group(1)
+
+
+def test_package_version_matches_pyproject() -> None:
+    """__version__ must equal the version declared in pyproject.toml."""
+    assert django_safe_migrations.__version__ == _pyproject_version()


### PR DESCRIPTION
## v0.6.1 hotfix batch

Fixes found during a full audit of `main`. All changes are bug-fix / stability / performance — no new rules or API changes.

### Fixed
- **Version desync** — `__version__` was stuck at `0.5.2` while the package shipped as `0.6.0`, which mislabeled the SARIF reporter's tool driver version in GitHub Code Scanning. Bumped to **0.6.1** and added a test asserting `__version__` matches `pyproject.toml`.
- **`SeparateDatabaseAndState` blind spot** — the analyzer now recurses into `database_operations`, so unsafe operations hidden inside the wrapper (NOT NULL `AddField`, non-concurrent `AddIndex`, `AddConstraint`, …) are detected. Previously they were silently skipped.
- **`--new-only` ignored exclusions** — now honors `EXCLUDED_APPS` and the default Django built-in exclusion, consistent with a full run.
- **`FAIL_ON_WARNING` setting was dead** — now honored by both the management command and the standalone CLI exit codes (previously only the `--fail-on-warning` flag worked).
- **`--diff` aborted on one bad file** — a changed file that doesn't resolve to a known migration (custom `AppConfig.label`, app not in `INSTALLED_APPS`, or a non-migration `.py` under `migrations/`) is now skipped with a warning instead of raising `CommandError` and killing the whole run. The standalone CLI now reports `DiffError` cleanly (exit 2) instead of a traceback.

### Security
- `--diff BASE_REF` now rejects refs starting with `-`, preventing git argument injection (e.g. `--output=<file>`, which could make git write the diff to an arbitrary path).

### Performance
- Resolve `AlterField` old-field state **once per operation** instead of once per rule (was ~25–36× redundant), and build the `MigrationLoader` **once per analysis run** instead of rebuilding it for every app and every `AlterField`. Removes an O(rules × migrations) blow-up — the test suite runs ~3.5× faster locally (4.7s → 1.3s).

### Docs / housekeeping
- Mark the `docs/roadmap/v0.6.0.md` rules/features as planned (not shipped); SM037–SM057 are deferred to v0.7.0 (see #30).
- Ignore the `test_db.sqlite3` test artifact.

### Verification
- 691 tests pass (8 new), 19 skipped; all pre-commit hooks (black, isort, flake8, bandit, mypy, mdformat, markdownlint) green.
- No regression: same 6 error / 12 warning / 10 info output on the test project.

Closes nothing automatically; relates to the `--diff`/`AppConfig.label` work in #45 (this composes with it — #45 may need a small rebase after merge).
