### PR TITLE
docs: remove emojis and fix accuracy issues from full docs review

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 | SM002   | `drop_column_unsafe`               | WARNING  | Dropping column while old code may reference it             |
 | SM003   | `drop_table_unsafe`                | WARNING  | Dropping table while old code may reference it              |
 | SM004   | `alter_column_type`                | WARNING  | Changing column type may rewrite table                      |
-| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks)               |
+| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks) (PostgreSQL)  |
 | SM006   | `rename_column`                    | INFO     | Column rename may break old code during deployment          |
 | SM007   | `run_sql_unsafe`                   | WARNING  | RunSQL without reverse_sql is not reversible                |
 | SM008   | `large_data_migration`             | INFO     | Data migration may be slow on large tables                  |
@@ -41,11 +41,11 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 | SM010   | `index_not_concurrent`             | ERROR    | Index creation without CONCURRENTLY (PostgreSQL)            |
 | SM011   | `unique_constraint_not_concurrent` | ERROR    | Unique constraint without concurrent index                  |
 | SM012   | `enum_add_value_transaction`       | ERROR    | Adding enum value inside transaction (PostgreSQL)           |
-| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table                    |
+| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table (PostgreSQL)       |
 | SM014   | `rename_model`                     | WARNING  | Model rename may break FKs and external references          |
 | SM015   | `alter_unique_together`            | WARNING  | Deprecated in favor of UniqueConstraint                     |
 | SM016   | `run_python_no_reverse`            | INFO     | RunPython without reverse_code is not reversible            |
-| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows                |
+| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows (PostgreSQL)   |
 | SM018   | `concurrent_in_atomic_migration`   | ERROR    | Concurrent index operations require atomic=False            |
 | SM019   | `reserved_keyword_column`          | INFO     | Column name is a reserved SQL keyword                       |
 | SM020   | `alter_field_null_false`           | ERROR    | AlterField null=False without data backfill                 |
@@ -330,16 +330,19 @@ Django Safe Migrations performs **static analysis** of migration files. It canno
 
 Some rules only apply to PostgreSQL:
 
-| Rule  | PostgreSQL Only | Reason                                              |
-| ----- | --------------- | --------------------------------------------------- |
-| SM010 | Yes             | `CONCURRENTLY` is PostgreSQL-specific               |
-| SM011 | Yes             | Concurrent unique indexes are PostgreSQL-specific   |
-| SM012 | Yes             | Enum handling is PostgreSQL-specific                |
-| SM018 | Yes             | `AddIndexConcurrently` is PostgreSQL-specific       |
-| SM021 | Yes             | Concurrent unique constraint pattern                |
-| SM030 | Yes             | `RemoveIndexConcurrently` is PostgreSQL-specific    |
-| SM031 | Yes             | TEXT vs VARCHAR optimization is PostgreSQL-specific |
-| SM034 | Yes             | IDENTITY columns are PostgreSQL-specific            |
+| Rule  | PostgreSQL Only | Reason                                                     |
+| ----- | --------------- | ---------------------------------------------------------- |
+| SM005 | Yes             | FK constraint validation is PostgreSQL-specific            |
+| SM010 | Yes             | `CONCURRENTLY` is PostgreSQL-specific                      |
+| SM011 | Yes             | Concurrent unique indexes are PostgreSQL-specific          |
+| SM012 | Yes             | Enum handling is PostgreSQL-specific                       |
+| SM013 | Yes             | VARCHAR length / ALTER TYPE rewrite is PostgreSQL-specific |
+| SM017 | Yes             | CHECK constraint validation is PostgreSQL-specific         |
+| SM018 | Yes             | `AddIndexConcurrently` is PostgreSQL-specific              |
+| SM021 | Yes             | Concurrent unique constraint pattern                       |
+| SM030 | Yes             | `RemoveIndexConcurrently` is PostgreSQL-specific           |
+| SM031 | Yes             | TEXT vs VARCHAR optimization is PostgreSQL-specific        |
+| SM034 | Yes             | IDENTITY columns are PostgreSQL-specific                   |
 
 For MySQL, SQLite, or other databases, these rules are automatically skipped.
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ python manage.py check_migrations --watch
 ```
 Found 2 migration issue(s):
 
-✖ ERROR [SM001] myapp/migrations/0002_add_email.py:15
+ERROR [SM001] myapp/migrations/0002_add_email.py:15
    Adding NOT NULL field 'email' to 'user' without a default value will lock the table
    Operation: AddField(user.email)
 
-   💡 Suggestion:
+   Suggestion:
       Safe pattern for adding NOT NULL field:
 
       1. Migration 1 - Add field as nullable:
@@ -153,7 +153,7 @@ Found 2 migration issue(s):
              field=models.CharField(max_length=255, null=False),
          )
 
-⚠ WARNING [SM002] myapp/migrations/0003_remove_old.py:10
+WARNING [SM002] myapp/migrations/0003_remove_old.py:10
    Dropping column 'old_field' from 'user' - ensure all code references have been removed first
    Operation: RemoveField(user.old_field)
 
@@ -161,7 +161,7 @@ Found 2 migration issue(s):
 Summary: 1 error(s), 1 warning(s)
 ```
 
-## 🔄 CI/CD Integration
+## CI/CD Integration
 
 ### GitHub Actions
 
@@ -205,7 +205,7 @@ repos:
         pass_filenames: false
 ```
 
-## ⚙️ Configuration
+## Configuration
 
 ### Command Options
 
@@ -248,11 +248,11 @@ for issue in issues:
         print(f"Suggestion: {issue.suggestion}")
 ```
 
-## 📚 Safe Migration Patterns
+## Safe Migration Patterns
 
 ### Adding a NOT NULL Column
 
-❌ **Unsafe:**
+**Unsafe:**
 
 ```python
 migrations.AddField(
@@ -262,7 +262,7 @@ migrations.AddField(
 )
 ```
 
-✅ **Safe:**
+**Safe:**
 
 ```python
 # Migration 1: Add nullable field
@@ -289,7 +289,7 @@ migrations.AlterField(
 
 ### Creating an Index (PostgreSQL)
 
-❌ **Unsafe:**
+**Unsafe:**
 
 ```python
 migrations.AddIndex(
@@ -298,7 +298,7 @@ migrations.AddIndex(
 )
 ```
 
-✅ **Safe:**
+**Safe:**
 
 ```python
 from django.contrib.postgres.operations import AddIndexConcurrently
@@ -314,7 +314,7 @@ class Migration(migrations.Migration):
     ]
 ```
 
-## ⚠️ Known Limitations
+## Known Limitations
 
 ### Static Analysis Only
 
@@ -375,7 +375,7 @@ Rules that inspect Python source code (like SM026 for RunPython batching) may no
 - Some Docker configurations
 - When source files are not available
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details.
 
@@ -395,17 +395,17 @@ pytest
 make lint
 ```
 
-## 📄 License
+## License
 
 MIT License - see [LICENSE](LICENSE) for details.
 
-## 💖 Support
+## Support
 
 If this project helps you ship safer migrations, consider supporting its development:
 
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-red.svg)](https://www.yasser-shkeir.com/donate)
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 Inspired by:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,8 +21,8 @@ ______________________________________________________________________
 
 The testing strategy is designed to ensure `django-safe-migrations` works correctly across:
 
-- **Python versions**: 3.9, 3.10, 3.11, 3.12, 3.13
-- **Django versions**: 3.2, 4.2, 5.0, 5.1
+- **Python versions**: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+- **Django versions**: 3.2, 4.2, 5.0, 5.1, 6.0
 - **Database backends**: SQLite, PostgreSQL, MySQL/MariaDB
 - **Operating systems**: Linux (Ubuntu), macOS, Windows
 
@@ -32,8 +32,9 @@ The testing strategy is designed to ensure `django-safe-migrations` works correc
 | ----------------- | --------------------------------------- | -------------------- | ------------- |
 | Unit Tests        | Test individual components in isolation | `tests/unit/`        | Every commit  |
 | Integration Tests | Test components working together        | `tests/integration/` | Every commit  |
-| Database Tests    | Test database-specific behavior         | `tests/database/`    | CI matrix     |
-| End-to-End Tests  | Test complete workflows                 | `tests/e2e/`         | PR/Release    |
+
+Database-specific behavior is covered within `tests/unit/` and `tests/integration/`,
+gated by the `@pytest.mark.postgres` and `@pytest.mark.mysql` markers.
 
 ______________________________________________________________________
 
@@ -42,16 +43,18 @@ ______________________________________________________________________
 ### Python × Django Compatibility Matrix
 
 ```
-             │ Django 3.2 │ Django 4.2 │ Django 5.0 │ Django 5.1 │
-─────────────┼────────────┼────────────┼────────────┼────────────┤
-Python 3.9   │    Yes     │    Yes     │     No     │     No     │
-Python 3.10  │    Yes     │    Yes     │    Yes     │    Yes     │
-Python 3.11  │    Yes     │    Yes     │    Yes     │    Yes     │
-Python 3.12  │     No     │    Yes     │    Yes     │    Yes     │
-Python 3.13  │     No     │    Yes     │    Yes     │    Yes     │
+             │ Django 3.2 │ Django 4.2 │ Django 5.0 │ Django 5.1 │ Django 6.0 │
+─────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+Python 3.9   │    Yes     │    Yes     │     No     │     No     │     No     │
+Python 3.10  │    Yes     │    Yes     │    Yes     │    Yes     │     No     │
+Python 3.11  │    Yes     │    Yes     │    Yes     │    Yes     │     No     │
+Python 3.12  │     No     │    Yes     │    Yes     │    Yes     │    Yes     │
+Python 3.13  │     No     │    Yes     │    Yes     │    Yes     │    Yes     │
+Python 3.14  │     No     │     No     │     No     │     No     │    Yes     │
 ```
 
-**Note**: Django 5.x requires Python 3.10+; Django 3.2 doesn't support Python 3.12+.
+**Note**: Django 5.0+ requires Python 3.10+; Django 6.0 requires Python 3.12+;
+Django 3.2 doesn't support Python 3.12+; Python 3.14 is only tested with Django 6.0.
 
 ### Using Tox for Matrix Testing
 
@@ -73,14 +76,15 @@ tox --listenvs
 
 ```ini
 [tox]
+isolated_build = True
 envlist =
     py39-django{32,42}
     py310-django{32,42,50,51}
-    py311-django{32,42,50,51}
-    py312-django{42,50,51}
-    py313-django{42,50,51}
+    py311-django{42,50,51}
+    py312-django{42,50,51,60}
+    py313-django{42,50,51,60}
     lint
-    type-check
+    typecheck
 
 [testenv]
 deps =
@@ -88,22 +92,35 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django60: Django>=6.0,<6.1
     pytest>=7.0
     pytest-django>=4.5
     pytest-cov>=4.0
+    pytest-xdist>=3.0
 commands =
-    pytest {posargs:tests/}
+    pytest tests -n 2 -q --cov=django_safe_migrations --cov-report=term-missing {posargs}
 
 [testenv:lint]
-deps = pre-commit
-commands = pre-commit run --all-files
+skip_install = true
+deps =
+    black>=22.0
+    flake8>=5.0
+    isort>=5.0
+commands =
+    black --check django_safe_migrations tests
+    isort --check-only django_safe_migrations tests
+    flake8 django_safe_migrations tests
 
-[testenv:type-check]
+[testenv:typecheck]
 deps =
     mypy>=1.0
     django-stubs>=4.0
-commands = mypy django_safe_migrations/
+    Django>=4.2
+commands =
+    mypy django_safe_migrations
 ```
+
+See the actual `tox.ini` in the repository for the full configuration.
 
 ______________________________________________________________________
 
@@ -158,16 +175,16 @@ pytest -x
 make test
 
 # Run tests with coverage
-make coverage
+make test-cov
 
 # Run linting
 make lint
 
 # Run type checking
-make type-check
+make typecheck
 
-# Run all checks
-make check
+# Run all CI checks (lint, typecheck, test)
+make ci-check
 ```
 
 ______________________________________________________________________
@@ -269,7 +286,7 @@ Create `docker-compose.test.yml`:
 version: "3.9"
 
 services:
-  # PostgreSQL Database
+  # PostgreSQL Database (exposed on host port 15432)
   postgres:
     image: postgres:15-alpine
     environment:
@@ -277,14 +294,14 @@ services:
       POSTGRES_USER: test_user
       POSTGRES_PASSWORD: test_password
     ports:
-      - "5432:5432"
+      - "15432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U test_user -d test_db"]
       interval: 5s
       timeout: 5s
       retries: 5
 
-  # MySQL Database
+  # MySQL Database (exposed on host port 13306)
   mysql:
     image: mysql:8.0
     environment:
@@ -293,14 +310,15 @@ services:
       MYSQL_PASSWORD: test_password
       MYSQL_ROOT_PASSWORD: root_password
     ports:
-      - "3306:3306"
+      - "13306:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 5s
       timeout: 5s
       retries: 5
 
-  # Test runner - Python 3.11
+  # Test runner - Python 3.11 (representative; the real file also defines
+  # test-py310, test-py312, test-py313, test-py314, test-mysql, and test-all-dbs)
   test-py311:
     build:
       context: .
@@ -313,44 +331,18 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgres://test_user:test_password@postgres:5432/test_db
-      - MYSQL_URL=mysql://test_user:test_password@mysql:3306/test_db
+      - DJANGO_SETTINGS_MODULE=tests.settings.postgres
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=test_db
+      - POSTGRES_USER=test_user
+      - POSTGRES_PASSWORD=test_password
     volumes:
       - .:/app
     command: pytest -v --cov=django_safe_migrations
-
-  # Test runner - Python 3.12
-  test-py312:
-    build:
-      context: .
-      dockerfile: Dockerfile.test
-      args:
-        PYTHON_VERSION: "3.12"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      - DATABASE_URL=postgres://test_user:test_password@postgres:5432/test_db
-    volumes:
-      - .:/app
-    command: pytest -v
-
-  # Test runner - Python 3.13
-  test-py313:
-    build:
-      context: .
-      dockerfile: Dockerfile.test
-      args:
-        PYTHON_VERSION: "3.13"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      - DATABASE_URL=postgres://test_user:test_password@postgres:5432/test_db
-    volumes:
-      - .:/app
-    command: pytest -v
 ```
+
+See the actual `docker-compose.test.yml` in the repository for the full configuration.
 
 ### Dockerfile.test
 
@@ -368,12 +360,14 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-COPY pyproject.toml .
+# Copy all source code first
+COPY . .
+
+# Install Python dependencies including the package itself and database drivers
 RUN pip install --no-cache-dir -e ".[dev,postgres,mysql]"
 
-# Copy source code
-COPY . .
+# Set PYTHONPATH to include the app directory
+ENV PYTHONPATH=/app
 
 # Run tests by default
 CMD ["pytest", "-v"]
@@ -383,16 +377,16 @@ CMD ["pytest", "-v"]
 
 ```bash
 # Run all tests with all databases
-docker-compose -f docker-compose.test.yml up --build
+docker compose -f docker-compose.test.yml up --build
 
 # Run specific Python version
-docker-compose -f docker-compose.test.yml up test-py312 --build
+docker compose -f docker-compose.test.yml up test-py312 --build
 
 # Run with specific database only
-docker-compose -f docker-compose.test.yml up postgres test-py311 --build
+docker compose -f docker-compose.test.yml up postgres test-py311 --build
 
 # Clean up
-docker-compose -f docker-compose.test.yml down -v
+docker compose -f docker-compose.test.yml down -v
 ```
 
 ______________________________________________________________________
@@ -475,20 +469,21 @@ DJANGO_SETTINGS_MODULE=tests.settings.mysql pytest
 
 ### Database-Specific Test Markers
 
-Use pytest markers to run database-specific tests:
+Use pytest markers to run database-specific tests. The markers themselves are
+declared in `pyproject.toml` under `[tool.pytest.ini_options]`, and `conftest.py`
+contains the skip-by-database-vendor logic that deselects tests when the active
+backend does not match the marker:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+markers = [
+    "postgres: mark test as requiring PostgreSQL",
+    "mysql: mark test as requiring MySQL",
+]
+```
 
 ```python
-# In conftest.py
-import pytest
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "postgres: mark test as requiring PostgreSQL"
-    )
-    config.addinivalue_line(
-        "markers", "mysql: mark test as requiring MySQL"
-    )
-
 # In test files
 @pytest.mark.postgres
 def test_concurrent_index_on_postgres():
@@ -514,148 +509,73 @@ ______________________________________________________________________
 
 **.github/workflows/ci.yml:**
 
+The CI workflow runs a Python x Django matrix on `ubuntu-latest`, with PostgreSQL
+and MySQL services attached to every matrix job (so SQLite, PostgreSQL, and MySQL
+are all exercised in a single test step). The matrix and its exclude rules mirror
+the supported-versions table above.
+
 ```yaml
 name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install pre-commit
-        run: pip install pre-commit
-      - name: Run pre-commit
-        run: pre-commit run --all-files
-
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["3.2", "4.2", "5.0", "5.1"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["3.2", "4.2", "5.0", "5.1", "6.0"]
         exclude:
-          # Django 5.x requires Python 3.10+
+          # Django 5.0+ requires Python 3.10+
           - python-version: "3.9"
             django-version: "5.0"
           - python-version: "3.9"
             django-version: "5.1"
+          # Django 6.0 requires Python 3.12+
+          - python-version: "3.9"
+            django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
           # Django 3.2 doesn't support Python 3.12+
           - python-version: "3.12"
             django-version: "3.2"
           - python-version: "3.13"
             django-version: "3.2"
+          - python-version: "3.14"
+            django-version: "3.2"
+          # Django 4.2 doesn't support Python 3.14
+          - python-version: "3.14"
+            django-version: "4.2"
+          # Django 5.0/5.1 don't support Python 3.14
+          - python-version: "3.14"
+            django-version: "5.0"
+          - python-version: "3.14"
+            django-version: "5.1"
 
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install Django~=${{ matrix.django-version }}.0
-          pip install -e ".[dev]"
-
-      - name: Run tests
-        run: pytest -v --cov=django_safe_migrations --cov-report=xml
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.11' && matrix.django-version == '4.2'
-
-  test-postgres:
-    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:15
-        env:
-          POSTGRES_DB: test_db
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: |
-          pip install -e ".[dev,postgres]"
-
-      - name: Run PostgreSQL tests
-        env:
-          DJANGO_SETTINGS_MODULE: tests.settings.postgres
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_DB: test_db
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-        run: pytest -v -m postgres
-
-  test-mysql:
-    runs-on: ubuntu-latest
-    services:
+        # ...
       mysql:
         image: mysql:8.0
-        env:
-          MYSQL_DATABASE: test_db
-          MYSQL_USER: test_user
-          MYSQL_PASSWORD: test_password
-          MYSQL_ROOT_PASSWORD: root_password
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+        # ...
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: |
-          pip install -e ".[dev,mysql]"
-
-      - name: Run MySQL tests
-        env:
-          DJANGO_SETTINGS_MODULE: tests.settings.mysql
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-          MYSQL_DB: test_db
-          MYSQL_USER: test_user
-          MYSQL_PASSWORD: test_password
-        run: pytest -v -m mysql
+      - uses: actions/checkout@v6
+      # Set up Python, install deps, then run SQLite / PostgreSQL / MySQL test steps.
+      # Coverage is uploaded only on Python 3.12 + Django 4.2.
 ```
+
+See the actual `.github/workflows/ci.yml` in the repository for the full configuration.
 
 ### Self-Hosted Runners
 
@@ -752,19 +672,20 @@ ______________________________________________________________________
 
 ```
 tests/
-├── conftest.py              # Shared fixtures
-├── unit/                    # Unit tests
+├── conftest.py              # Shared fixtures + DB-vendor skip logic
+├── unit/                    # Unit tests (DB-specific tests gated by markers)
 │   ├── rules/
 │   │   ├── test_add_field_rules.py
 │   │   ├── test_add_index_rules.py
 │   │   └── test_remove_field_rules.py
 │   ├── test_analyzer.py
 │   └── test_reporters.py
-├── integration/             # Integration tests
+├── integration/             # Integration tests (DB-specific tests gated by markers)
 │   └── test_command.py
-├── database/                # Database-specific tests
-│   ├── test_postgres.py
-│   └── test_mysql.py
+├── settings/                # Per-database test settings
+│   ├── sqlite.py
+│   ├── postgres.py
+│   └── mysql.py
 └── test_project/            # Test Django project
     ├── manage.py
     ├── settings.py
@@ -869,7 +790,7 @@ ______________________________________________________________________
 
 ### Getting Help
 
-- Open an issue: https://github.com/username/django-safe-migrations/issues
+- Open an issue: https://github.com/YasserShkeir/django-safe-migrations/issues
 - Check existing discussions
 - Review CI logs for detailed error messages
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -44,11 +44,11 @@ ______________________________________________________________________
 ```
              │ Django 3.2 │ Django 4.2 │ Django 5.0 │ Django 5.1 │
 ─────────────┼────────────┼────────────┼────────────┼────────────┤
-Python 3.9   │     ✅     │     ✅     │     ❌     │     ❌     │
-Python 3.10  │     ✅     │     ✅     │     ✅     │     ✅     │
-Python 3.11  │     ✅     │     ✅     │     ✅     │     ✅     │
-Python 3.12  │     ❌     │     ✅     │     ✅     │     ✅     │
-Python 3.13  │     ❌     │     ✅     │     ✅     │     ✅     │
+Python 3.9   │    Yes     │    Yes     │     No     │     No     │
+Python 3.10  │    Yes     │    Yes     │    Yes     │    Yes     │
+Python 3.11  │    Yes     │    Yes     │    Yes     │    Yes     │
+Python 3.12  │     No     │    Yes     │    Yes     │    Yes     │
+Python 3.13  │     No     │    Yes     │    Yes     │    Yes     │
 ```
 
 **Note**: Django 5.x requires Python 3.10+; Django 3.2 doesn't support Python 3.12+.
@@ -405,11 +405,11 @@ Some rules only apply to specific databases:
 
 | Rule                        | SQLite | PostgreSQL | MySQL |
 | --------------------------- | ------ | ---------- | ----- |
-| SM001 (NOT NULL)            | ✅     | ✅         | ✅    |
-| SM002 (Drop Column)         | ✅     | ✅         | ✅    |
-| SM003 (Drop Table)          | ✅     | ✅         | ✅    |
-| SM010 (Index CONCURRENTLY)  | ❌     | ✅         | ❌    |
-| SM011 (Unique CONCURRENTLY) | ❌     | ✅         | ❌    |
+| SM001 (NOT NULL)            | Yes    | Yes        | Yes   |
+| SM002 (Drop Column)         | Yes    | Yes        | Yes   |
+| SM003 (Drop Table)          | Yes    | Yes        | Yes   |
+| SM010 (Index CONCURRENTLY)  | No     | Yes        | No    |
+| SM011 (Unique CONCURRENTLY) | No     | Yes        | No    |
 
 ### Test Settings per Database
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -287,7 +287,7 @@ analyzer = MigrationAnalyzer(rules=rules)
 
 ## Module Exports
 
-The main module exports these public classes:
+The main module exports these public names:
 
 ```python
 from django_safe_migrations import (

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,10 +40,10 @@ This document describes the high-level architecture of django-safe-migrations.
                                   │
                     ┌─────────────┼─────────────┐
                     ▼             ▼             ▼
-              ┌──────────┐ ┌──────────┐ ┌──────────┐
-              │ Console  │ │  JSON    │ │  SARIF   │
-              │ Reporter │ │ Reporter │ │ Reporter │
-              └──────────┘ └──────────┘ └──────────┘
+              ┌────────────────────────────────────┐
+              │ Reporters                          │
+              │ (console/json/github/gitlab/sarif) │
+              └────────────────────────────────────┘
 ```
 
 ## Core Components
@@ -94,10 +94,10 @@ The core analysis engine:
 class MigrationAnalyzer:
     def __init__(
         self,
-        db_vendor: str = "postgresql",
         rules: list[BaseRule] | None = None,
+        db_vendor: str | None = None,
         disabled_rules: set[str] | None = None,
-        excluded_apps: set[str] | None = None,
+        verbose: bool = False,
     ):
         ...
 
@@ -185,11 +185,11 @@ Rules are organized by the operation type they check:
 rules/
 ├── __init__.py        # Rule registry, get_all_rules()
 ├── base.py            # BaseRule, Issue, Severity
-├── add_field.py       # SM001, SM022
+├── add_field.py       # SM001, SM022, SM028, SM031-SM034
 ├── remove_field.py    # SM002, SM003
-├── alter_field.py     # SM004-SM006, SM013-SM014, SM020-SM021
-├── run_sql.py         # SM007-SM008, SM012, SM016, SM024, SM026
-├── add_index.py       # SM010-SM011, SM018
+├── alter_field.py     # SM004-SM006, SM013-SM014, SM020-SM021, SM029
+├── run_sql.py         # SM007-SM008, SM012, SM016, SM024, SM026, SM035-SM036
+├── add_index.py       # SM010-SM011, SM018, SM030
 ├── constraints.py     # SM009, SM015, SM017
 ├── naming.py          # SM019
 ├── relations.py       # SM023, SM025
@@ -225,19 +225,19 @@ def get_rule_by_id(rule_id: str) -> type[BaseRule] | None:
 Handles settings from `settings.SAFE_MIGRATIONS`:
 
 ```python
-def get_safe_migrations_settings() -> dict:
+def get_config() -> dict:
     """Get the SAFE_MIGRATIONS dict from Django settings."""
     ...
 
-def get_disabled_rules() -> set[str]:
+def get_disabled_rules() -> list[str]:
     """Get disabled rule IDs."""
     ...
 
-def get_disabled_categories() -> set[str]:
+def get_disabled_categories() -> list[str]:
     """Get disabled categories."""
     ...
 
-def get_excluded_apps() -> set[str]:
+def get_excluded_apps() -> list[str]:
     """Get excluded app labels."""
     ...
 
@@ -250,7 +250,7 @@ def validate_config() -> list[str]:
     ...
 ```
 
-### Reporters (`reporters.py`, `sarif_reporter.py`, `reporters/`)
+### Reporters (`reporters/`)
 
 Format issues for output:
 
@@ -260,7 +260,7 @@ class ConsoleReporter:
     def report(self, issues: list[Issue]) -> str:
         ...
 
-class JSONReporter:
+class JsonReporter:
     """Machine-readable JSON output."""
     def report(self, issues: list[Issue]) -> str:
         ...
@@ -270,7 +270,7 @@ class GitHubReporter:
     def report(self, issues: list[Issue]) -> str:
         ...
 
-class SARIFReporter:
+class SarifReporter:
     """SARIF format for code scanning."""
     def report(self, issues: list[Issue]) -> str:
         ...
@@ -287,15 +287,16 @@ Handles inline suppression comments:
 
 ```python
 def is_operation_suppressed(
-    migration,
-    operation,
+    file_path: str,
+    operation_line: int,
     rule_id: str,
+    suppressions: dict[int, Suppression] | None = None,
 ) -> bool:
     """Check if operation is suppressed for a rule."""
     ...
 
-def parse_suppression_comment(comment: str) -> set[str]:
-    """Parse rule IDs from suppression comment."""
+def parse_suppression_comment(line: str, line_number: int) -> Suppression | None:
+    """Parse rule IDs from a suppression comment."""
     # Recognizes: # safe-migrations: ignore SM001, SM002
     ...
 ```
@@ -444,8 +445,8 @@ django-safe-migrations is **single-threaded**:
 
 ### Required
 
-- Python 3.10+
-- Django 4.2+
+- Python 3.9+
+- Django 3.2+
 
 ### Optional
 
@@ -458,20 +459,26 @@ django-safe-migrations is **single-threaded**:
 django_safe_migrations/
 ├── __init__.py              # Package exports, version
 ├── analyzer.py              # Core MigrationAnalyzer
+├── apps.py                  # Django AppConfig
 ├── baseline.py              # Baseline support for suppressing known issues
 ├── cli.py                   # Standalone CLI
 ├── conf.py                  # Configuration handling
 ├── diff.py                  # Git-based diff mode for checking only changed migrations
 ├── interactive.py           # Interactive review mode for triaging issues
-├── reporters.py             # Output formatters
-├── sarif_reporter.py        # SARIF format support
 ├── suppression.py           # Inline suppression
+├── utils.py                 # Shared helpers (before-state resolution, etc.)
 ├── watch.py                 # File watcher for continuous analysis (requires watchdog)
 ├── management/
 │   └── commands/
 │       └── check_migrations.py  # Django command
 ├── reporters/
-│   └── gitlab.py            # GitLab Code Quality reporter
+│   ├── __init__.py          # Reporter registry
+│   ├── base.py              # BaseReporter
+│   ├── console.py           # ConsoleReporter
+│   ├── json_reporter.py     # JsonReporter
+│   ├── github.py            # GitHubReporter
+│   ├── gitlab.py            # GitLabReporter (GitLab Code Quality)
+│   └── sarif.py             # SarifReporter (SARIF code scanning)
 └── rules/
     ├── __init__.py          # Rule registry
     ├── base.py              # BaseRule, Issue, Severity

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -500,14 +500,19 @@ Output:
       "severity": "error",
       "operation": "AddField(user.email)",
       "message": "Adding NOT NULL field 'email' without default",
+      "suggestion": "Add a default value or make the field nullable",
       "file_path": "myapp/migrations/0002_add_email.py",
-      "line_number": 15
+      "line_number": 15,
+      "app_label": "myapp",
+      "migration_name": "0002_add_email"
     }
   ],
   "summary": {
     "errors": 1,
     "warnings": 1,
-    "by_rule": { "SM001": 1, "SM002": 1 }
+    "info": 0,
+    "by_rule": { "SM001": 1, "SM002": 1 },
+    "by_app": { "myapp": 2 }
   }
 }
 ```

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -41,4 +41,4 @@ ______________________________________________________________________
 
 1. **Hybrid Ruleset**: We cover both "scary locking operations" (like `strong_migrations`) and "unsafe dropping of data" (like the linter).
 2. **Suggestive Fixes**: We don't just say "Error". We output the actual Python code snippet you should specifically use to fix the issue (e.g., proper 3-step migration for adding a column).
-3. **Modern Ecosystem**: Built from the ground up for GitHub Actions (annotations support) and modern Django versions (3.2 - 5.1+).
+3. **Modern Ecosystem**: Built from the ground up for GitHub Actions (annotations support) and modern Django versions (3.2 - 6.0).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,7 @@ SAFE_MIGRATIONS = {
         "oauth2_provider",
     ],
 
-    # Per-app rule configuration (v0.3.0+)
+    # Per-app rule configuration
     "APP_RULES": {
         "legacy_app": {
             "DISABLED_RULES": ["SM001", "SM002"],  # Relax rules for legacy
@@ -68,20 +68,25 @@ SAFE_MIGRATIONS = {
 
 Disable entire categories of rules at once. Available categories:
 
-| Category          | Description               | Rules                                           |
-| ----------------- | ------------------------- | ----------------------------------------------- |
-| `postgresql`      | PostgreSQL-specific rules | SM005, SM010, SM011, SM012, SM013, SM018        |
-| `indexes`         | Index-related operations  | SM010, SM011, SM018                             |
-| `constraints`     | Constraint operations     | SM009, SM011, SM015, SM017                      |
-| `destructive`     | Destructive operations    | SM002, SM003, SM009                             |
-| `locking`         | Table-locking operations  | SM004, SM005, SM010, SM011, SM013               |
-| `data-loss`       | Potential data loss       | SM002, SM003, SM009                             |
-| `reversibility`   | Non-reversible migrations | SM007, SM016, SM017                             |
-| `data-migrations` | Data migration concerns   | SM007, SM008, SM016, SM017                      |
-| `high-risk`       | High-risk operations      | SM001, SM002, SM003, SM010, SM011, SM018        |
-| `informational`   | Info-level warnings       | SM006, SM014, SM019                             |
-| `naming`          | Naming convention rules   | SM019                                           |
-| `schema-changes`  | Schema modification rules | SM001, SM002, SM003, SM004, SM006, SM013, SM014 |
+| Category          | Description               | Rules                                                                                            |
+| ----------------- | ------------------------- | ------------------------------------------------------------------------------------------------ |
+| `postgresql`      | PostgreSQL-specific rules | SM005, SM010, SM011, SM012, SM013, SM018, SM021, SM030, SM031, SM034                             |
+| `mysql`           | MySQL-specific rules      | (none currently)                                                                                 |
+| `sqlite`          | SQLite-specific rules     | (none currently)                                                                                 |
+| `indexes`         | Index-related operations  | SM010, SM011, SM018, SM021, SM030                                                                |
+| `constraints`     | Constraint operations     | SM009, SM011, SM015, SM017, SM020, SM021                                                         |
+| `destructive`     | Destructive operations    | SM002, SM003, SM009                                                                              |
+| `relations`       | Relation operations       | SM005, SM023, SM025                                                                              |
+| `locking`         | Table-locking operations  | SM004, SM005, SM010, SM011, SM013, SM020, SM021, SM030                                           |
+| `data-loss`       | Potential data loss       | SM002, SM003, SM009, SM029                                                                       |
+| `reversibility`   | Non-reversible migrations | SM007, SM016, SM017                                                                              |
+| `data-migrations` | Data migration concerns   | SM007, SM008, SM016, SM017, SM022, SM026                                                         |
+| `security`        | Security-related rules    | SM024                                                                                            |
+| `high-risk`       | High-risk operations      | SM001, SM002, SM003, SM010, SM011, SM018, SM020, SM021, SM024, SM027, SM030                      |
+| `informational`   | Info-level warnings       | SM006, SM014, SM019, SM023, SM031, SM032, SM034, SM035, SM036                                    |
+| `naming`          | Naming convention rules   | SM019                                                                                            |
+| `schema-changes`  | Schema modification rules | SM001, SM002, SM003, SM004, SM006, SM013, SM014, SM020, SM021, SM023, SM027, SM028, SM029, SM033 |
+| `performance`     | Performance concerns      | SM022, SM025, SM026, SM028, SM033                                                                |
 
 ```python
 SAFE_MIGRATIONS = {
@@ -322,6 +327,15 @@ Hide the fix suggestions in output:
 
 ```bash
 python manage.py check_migrations --no-suggestions
+```
+
+### `--output` / `-o`
+
+Write the report to a file instead of stdout:
+
+```bash
+python manage.py check_migrations --format=json --output report.json
+python manage.py check_migrations --format=sarif -o results.sarif
 ```
 
 ### `--exclude-apps`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,10 +262,10 @@ migrations.RunSQL(
 2. **Be specific** — Only suppress the rules that apply:
 
    ```python
-   # ✅ Good - specific
+   # Good - specific
    # safe-migrations: ignore SM001
 
-   # ❌ Avoid - too broad
+   # Avoid - too broad
    # safe-migrations: ignore all
    ```
 
@@ -473,7 +473,7 @@ Each path must be a fully qualified dotted path to a class that extends `BaseRul
 
 #### Security Considerations
 
-> ⚠️ **Important:** The `EXTRA_RULES` setting uses dynamic imports via `importlib.import_module()`.
+> **Important:** The `EXTRA_RULES` setting uses dynamic imports via `importlib.import_module()`.
 
 **Risk Assessment:**
 
@@ -492,12 +492,12 @@ Each path must be a fully qualified dotted path to a class that extends `BaseRul
 3. **Don't use user input** - Never construct `EXTRA_RULES` paths from user-supplied data:
 
    ```python
-   # ❌ NEVER DO THIS
+   # NEVER DO THIS
    SAFE_MIGRATIONS = {
        "EXTRA_RULES": [os.environ.get("CUSTOM_RULE")],  # Dangerous!
    }
 
-   # ✅ SAFE - hardcoded paths only
+   # SAFE - hardcoded paths only
    SAFE_MIGRATIONS = {
        "EXTRA_RULES": ["myapp.rules.MyRule"],
    }

--- a/docs/detected-patterns.md
+++ b/docs/detected-patterns.md
@@ -580,12 +580,19 @@ ______________________________________________________________________
 ### The Unsafe Pattern
 
 ```python
+# testapp/migrations/0021_autofield_primary_key.py
+
 class Migration(migrations.Migration):
     operations = [
-        migrations.AddField(
-            model_name='order',
-            name='id',
-            field=models.AutoField(primary_key=True),
+        migrations.CreateModel(
+            name="LegacyItem",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(primary_key=True, serialize=False),
+                ),
+                ("name", models.CharField(max_length=100)),
+            ],
         ),
     ]
 ```
@@ -593,7 +600,7 @@ class Migration(migrations.Migration):
 ### Tool Output
 
 ```
-WARNING [SM028] myapp/migrations/0021_autofield.py
+WARNING [SM028] testapp/migrations/0021_autofield_primary_key.py
   Prefer BigAutoField over 32-bit AutoField for primary keys.
   32-bit integers max out at ~2.1 billion rows.
 ```
@@ -618,11 +625,13 @@ ______________________________________________________________________
 ### The Unsafe Pattern
 
 ```python
+# testapp/migrations/0023_remove_index.py
+
 class Migration(migrations.Migration):
     operations = [
         migrations.RemoveIndex(
-            model_name='order',
-            name='order_status_idx',
+            model_name='user',
+            name='testapp_user_uname_idx',
         ),
     ]
 ```
@@ -630,7 +639,7 @@ class Migration(migrations.Migration):
 ### Tool Output
 
 ```
-ERROR [SM030] myapp/migrations/0023_remove_index.py
+ERROR [SM030] testapp/migrations/0023_remove_index.py
   Index removal without CONCURRENTLY will lock the table on PostgreSQL.
 ```
 
@@ -652,8 +661,8 @@ class Migration(migrations.Migration):
 
     operations = [
         RemoveIndexConcurrently(
-            model_name='order',
-            name='order_status_idx',
+            model_name='user',
+            name='testapp_user_uname_idx',
         ),
     ]
 ```
@@ -667,12 +676,14 @@ ______________________________________________________________________
 ### The Unsafe Pattern
 
 ```python
+# testapp/migrations/0024_field_with_default.py
+
 class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
-            model_name='order',
+            model_name='user',
             name='status',
-            field=models.CharField(max_length=20, default='pending'),
+            field=models.CharField(max_length=20, default='active'),
         ),
     ]
 ```
@@ -680,7 +691,7 @@ class Migration(migrations.Migration):
 ### Tool Output
 
 ```
-WARNING [SM033] myapp/migrations/0025_add_status.py
+WARNING [SM033] testapp/migrations/0024_field_with_default.py
   Adding NOT NULL field with Python default rewrites all existing rows.
 ```
 
@@ -699,9 +710,9 @@ When you add a NOT NULL column with a Python-level `default`:
 # Django 5.0+: Use db_default to set the default at the database level
 # without rewriting existing rows on supported databases
 migrations.AddField(
-    model_name='order',
+    model_name='user',
     name='status',
-    field=models.CharField(max_length=20, db_default='pending'),
+    field=models.CharField(max_length=20, db_default='active'),
 )
 ```
 
@@ -714,10 +725,13 @@ ______________________________________________________________________
 ### The Unsafe Pattern
 
 ```python
+# testapp/migrations/0025_run_sql_no_lock_timeout.py
+
 class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
-            sql="ALTER TABLE myapp_order ADD COLUMN priority INTEGER DEFAULT 0;",
+            sql="ALTER TABLE testapp_user ADD COLUMN temp_col INTEGER",
+            reverse_sql="ALTER TABLE testapp_user DROP COLUMN temp_col",
         ),
     ]
 ```
@@ -725,7 +739,7 @@ class Migration(migrations.Migration):
 ### Tool Output
 
 ```
-INFO [SM035] myapp/migrations/0026_alter_order.py
+INFO [SM035] testapp/migrations/0025_run_sql_no_lock_timeout.py
   RunSQL with DDL should set lock_timeout to avoid blocking.
 ```
 
@@ -739,9 +753,9 @@ DDL statements like `ALTER TABLE` acquire locks that can block other queries. Wi
 migrations.RunSQL(
     sql=[
         "SET lock_timeout = '5s';",
-        "ALTER TABLE myapp_order ADD COLUMN priority INTEGER DEFAULT 0;",
+        "ALTER TABLE testapp_user ADD COLUMN temp_col INTEGER",
     ],
-    reverse_sql="ALTER TABLE myapp_order DROP COLUMN priority;",
+    reverse_sql="ALTER TABLE testapp_user DROP COLUMN temp_col",
 )
 ```
 
@@ -768,6 +782,6 @@ You should see output detecting all the unsafe patterns documented above.
 
 ## See Also
 
-- [Rules Reference](rules/index.md) - Detailed documentation for each rule
+- [Rules Reference](rules.md) - Detailed documentation for each rule
 - [Safe Patterns](patterns.md) - Comprehensive guide to safe migration patterns
 - [Configuration](configuration.md) - How to suppress or configure rules

--- a/docs/django-compatibility.md
+++ b/docs/django-compatibility.md
@@ -10,15 +10,16 @@ Django Safe Migrations supports a wide range of Django and Python versions. This
 | ------ | ---------- | ---------- | ---------- | ---------- | ---------- |
 | 3.9    | Yes        | Yes        | No         | No         | No         |
 | 3.10   | Yes        | Yes        | Yes        | Yes        | No         |
-| 3.11   | Yes        | Yes        | Yes        | Yes        | Yes        |
-| 3.12   | Yes        | Yes        | Yes        | Yes        | Yes        |
+| 3.11   | Yes        | Yes        | Yes        | Yes        | No         |
+| 3.12   | No         | Yes        | Yes        | Yes        | Yes        |
 | 3.13   | No         | Yes        | Yes        | Yes        | Yes        |
+| 3.14   | No         | No         | No         | No         | Yes        |
 
 **Notes:**
 
 - Django 3.2 is the minimum supported version (LTS)
 - Django 5.0+ requires Python 3.10+
-- Django 6.0+ requires Python 3.11+
+- Django 6.0+ requires Python 3.12+
 - Python 3.9 support will be dropped when Django 3.2 reaches end-of-life
 
 ### Official Support Policy
@@ -42,7 +43,7 @@ Django's internal APIs change between versions. We handle these automatically so
 | < 5.1          | `check=`       | Required             |
 | 5.1            | `check=`       | Deprecated (warning) |
 | 5.1            | `condition=`   | New, preferred       |
-| 6.0+           | `check=`       | Removed              |
+| 6.0+           | `check=`       | Removed (planned)    |
 | 6.0+           | `condition=`   | Required             |
 
 **How We Handle It:**
@@ -96,8 +97,9 @@ Every pull request runs tests against our full version matrix using GitHub Actio
 
 ```yaml
 strategy:
+  fail-fast: false
   matrix:
-    python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     django-version: ["3.2", "4.2", "5.0", "5.1", "6.0"]
     exclude:
       # Django 5.0+ requires Python 3.10+
@@ -105,14 +107,28 @@ strategy:
         django-version: "5.0"
       - python-version: "3.9"
         django-version: "5.1"
+      # Django 6.0 requires Python 3.12+
       - python-version: "3.9"
         django-version: "6.0"
-      # Django 6.0 requires Python 3.11+
       - python-version: "3.10"
         django-version: "6.0"
-      # Python 3.13 not supported on Django 3.2
+      - python-version: "3.11"
+        django-version: "6.0"
+      # Django 3.2 doesn't support Python 3.12+
+      - python-version: "3.12"
+        django-version: "3.2"
       - python-version: "3.13"
         django-version: "3.2"
+      - python-version: "3.14"
+        django-version: "3.2"
+      # Django 4.2 doesn't support Python 3.14
+      - python-version: "3.14"
+        django-version: "4.2"
+      # Django 5.0/5.1 don't support Python 3.14
+      - python-version: "3.14"
+        django-version: "5.0"
+      - python-version: "3.14"
+        django-version: "5.1"
 ```
 
 ### Docker Multi-Database Testing
@@ -220,10 +236,20 @@ While django-safe-migrations performs static analysis (no database connection re
 
 | Rule       | PostgreSQL | MySQL | SQLite | Other |
 | ---------- | ---------- | ----- | ------ | ----- |
+| SM005      | Yes        | No    | No     | No    |
 | SM010      | Yes        | No    | No     | No    |
 | SM011      | Yes        | No    | No     | No    |
 | SM012      | Yes        | No    | No     | No    |
+| SM013      | Yes        | No    | No     | No    |
+| SM017      | Yes        | No    | No     | No    |
+| SM018      | Yes        | No    | No     | No    |
+| SM021      | Yes        | No    | No     | No    |
+| SM030      | Yes        | No    | No     | No    |
+| SM031      | Yes        | No    | No     | No    |
+| SM034      | Yes        | No    | No     | No    |
 | All others | Yes        | Yes   | Yes    | Yes   |
+
+SM031 and SM034 are informational PostgreSQL-only rules; SM034 only fires on Django < 4.0.
 
 Database-specific rules use the `db_vendors` attribute:
 

--- a/docs/github-code-scanning.md
+++ b/docs/github-code-scanning.md
@@ -87,13 +87,13 @@ The SARIF output includes:
     "tool": {
       "driver": {
         "name": "django-safe-migrations",
-        "version": "0.2.0",
+        "version": "0.6.1",
         "rules": [
           {
             "id": "SM001",
             "name": "NotNullWithoutDefaultRule",
             "shortDescription": { "text": "Adding NOT NULL column without default" },
-            "helpUri": "https://django-safe-migrations.readthedocs.io/en/latest/rules/SM001/"
+            "helpUri": "https://github.com/YasserShkeir/django-safe-migrations/blob/main/docs/rules.md"
           }
         ]
       }

--- a/docs/github-code-scanning.md
+++ b/docs/github-code-scanning.md
@@ -119,9 +119,9 @@ The SARIF output includes:
 
 | django-safe-migrations | SARIF Level | GitHub Display |
 | ---------------------- | ----------- | -------------- |
-| ERROR                  | `error`     | 🔴 Error       |
-| WARNING                | `warning`   | 🟡 Warning     |
-| INFO                   | `note`      | 🔵 Note        |
+| ERROR                  | `error`     | Error          |
+| WARNING                | `warning`   | Warning        |
+| INFO                   | `note`      | Note           |
 
 ## Command Options
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ ERROR [SM001] myapp/migrations/0002_add_email.py:15
 ## Features
 
 - **36 built-in rules** covering schema changes, locking, data loss, and best practices
-- **PostgreSQL-aware** rules for concurrent indexes, TEXT vs VARCHAR, IDENTITY columns
+- **Database-aware** rules, including PostgreSQL-specific checks for concurrent indexes, TEXT vs VARCHAR, and IDENTITY columns, plus MySQL- and SQLite-specific categories
 - **Fix suggestions** with safe migration patterns for every issue
 - **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output
 - **Fast** — static analysis without running migrations

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,11 @@ $ python manage.py check_migrations
 
 Found 1 migration issue(s):
 
-✖ ERROR [SM001] myapp/migrations/0002_add_email.py:15
+ERROR [SM001] myapp/migrations/0002_add_email.py:15
    Adding NOT NULL field 'email' to 'user' without a default value will lock the table
    Operation: AddField(user.email)
 
-   💡 Suggestion:
+   Suggestion:
       1. Add field as nullable first
       2. Backfill existing rows
       3. Add NOT NULL constraint in separate migration
@@ -38,15 +38,15 @@ Found 1 migration issue(s):
 
 ## Features
 
-- 🔍 **36 built-in rules** covering schema changes, locking, data loss, and best practices
-- 🐘 **PostgreSQL-aware** rules for concurrent indexes, TEXT vs VARCHAR, IDENTITY columns
-- 💡 **Fix suggestions** with safe migration patterns for every issue
-- 🔧 **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output
-- ⚡ **Fast** — static analysis without running migrations
-- 📊 **Baseline support** — suppress existing issues, catch only new ones
-- 🔀 **Diff mode** — only check migrations changed since a branch
-- 🖥️ **Interactive mode** — review and triage issues one-by-one
-- 👀 **Watch mode** — re-run on file changes during development
+- **36 built-in rules** covering schema changes, locking, data loss, and best practices
+- **PostgreSQL-aware** rules for concurrent indexes, TEXT vs VARCHAR, IDENTITY columns
+- **Fix suggestions** with safe migration patterns for every issue
+- **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output
+- **Fast** — static analysis without running migrations
+- **Baseline support** — suppress existing issues, catch only new ones
+- **Diff mode** — only check migrations changed since a branch
+- **Interactive mode** — review and triage issues one-by-one
+- **Watch mode** — re-run on file changes during development
 
 ## Getting Started
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,13 +49,18 @@ Run the management command:
 python manage.py check_migrations --help
 ```
 
-You should see:
+You should see the command's help text listing the available options,
+including the output formats and flags:
 
 ```
-usage: manage.py check_migrations [-h] [--format {console,json,github}]
-                                  [--fail-on-warning] [--new-only]
-                                  [--no-suggestions] [--exclude-apps ...]
-                                  [--include-django-apps]
+usage: manage.py check_migrations [-h]
+                                  [--format {console,json,github,gitlab,sarif}]
+                                  [--output OUTPUT] [--fail-on-warning]
+                                  [--new-only] [--no-suggestions]
+                                  [--exclude-apps ...] [--include-django-apps]
+                                  [--diff] [--baseline BASELINE]
+                                  [--generate-baseline] [--interactive]
+                                  [--watch] [--list-rules] [--verbose]
                                   [app_labels ...]
 
 Check migrations for unsafe operations

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -17,7 +17,7 @@ On large tables, this can lock the table for minutes or hours.
 ### Unsafe Pattern
 
 ```python
-# ❌ This will lock the table and fail if rows exist
+# This will lock the table and fail if rows exist
 migrations.AddField(
     model_name='user',
     name='email',
@@ -74,7 +74,7 @@ Standard index creation locks the table for writes during the entire operation.
 ### Unsafe Pattern
 
 ```python
-# ❌ Locks table for writes
+# Locks table for writes
 migrations.AddIndex(
     model_name='user',
     index=models.Index(fields=['email'], name='user_email_idx'),
@@ -113,7 +113,7 @@ Adding a unique constraint requires a full table scan and locks the table.
 ### Unsafe Pattern
 
 ```python
-# ❌ Locks table, scans all rows
+# Locks table, scans all rows
 migrations.AddConstraint(
     model_name='user',
     constraint=models.UniqueConstraint(fields=['email'], name='unique_email'),
@@ -161,7 +161,7 @@ Adding a foreign key validates all existing rows, which can be slow on large tab
 ### Unsafe Pattern
 
 ```python
-# ❌ Validates all existing rows
+# Validates all existing rows
 migrations.AddField(
     model_name='order',
     name='user',
@@ -205,7 +205,7 @@ During rolling deployments, old code may still reference the column.
 ### Unsafe Pattern
 
 ```python
-# ❌ Old code will crash trying to SELECT this column
+# Old code will crash trying to SELECT this column
 migrations.RemoveField(
     model_name='user',
     name='legacy_field',
@@ -244,7 +244,7 @@ Renaming breaks all existing code referencing the old name.
 ### Unsafe Pattern
 
 ```python
-# ❌ Old code will crash
+# Old code will crash
 migrations.RenameField(
     model_name='user',
     old_name='name',
@@ -316,7 +316,7 @@ Adding a CHECK constraint validates all existing rows.
 ### Unsafe Pattern
 
 ```python
-# ❌ Scans and locks table
+# Scans and locks table
 migrations.AddConstraint(
     model_name='order',
     constraint=models.CheckConstraint(
@@ -356,7 +356,7 @@ ______________________________________________________________________
 ### Always Provide Reverse SQL
 
 ```python
-# ✅ Reversible
+# Reversible
 migrations.RunSQL(
     sql='CREATE INDEX user_email_idx ON myapp_user(email);',
     reverse_sql='DROP INDEX user_email_idx;',
@@ -364,7 +364,7 @@ migrations.RunSQL(
 ```
 
 ```python
-# ❌ Not reversible - migration cannot be rolled back
+# Not reversible - migration cannot be rolled back
 migrations.RunSQL(
     sql='CREATE INDEX user_email_idx ON myapp_user(email);',
 )
@@ -439,7 +439,7 @@ Adding enum values inside a transaction fails on PostgreSQL.
 ### Unsafe Pattern
 
 ```python
-# ❌ Fails: cannot add enum value inside transaction
+# Fails: cannot add enum value inside transaction
 migrations.RunSQL("ALTER TYPE myenum ADD VALUE 'new_value';")
 ```
 
@@ -472,7 +472,7 @@ to verify no NULL values exist. If NULL values exist, the migration fails.
 ### Unsafe Pattern
 
 ```python
-# ❌ Will fail if any NULL values exist
+# Will fail if any NULL values exist
 migrations.AlterField(
     model_name='user',
     name='nickname',
@@ -543,7 +543,7 @@ blocking writes for the duration of index creation.
 ### Unsafe Pattern
 
 ```python
-# ❌ Locks table during index creation
+# Locks table during index creation
 migrations.AlterField(
     model_name='user',
     name='email',
@@ -632,7 +632,7 @@ with `db_index=False`, JOIN queries can become very slow on large tables.
 ### Pattern to Avoid
 
 ```python
-# ❌ No index means slow JOINs
+# No index means slow JOINs
 migrations.AddField(
     model_name='order',
     name='customer',
@@ -651,7 +651,7 @@ migrations.AddField(
 - The field is never used in WHERE or JOIN clauses
 
 ```python
-# ✅ OK if you have a covering index
+# OK if you have a covering index
 migrations.AddField(
     model_name='order',
     name='customer',
@@ -732,7 +732,7 @@ Using `.all()` without `.iterator()` loads the entire table into memory.
 ### Unsafe Pattern
 
 ```python
-# ❌ Loads all rows into memory at once
+# Loads all rows into memory at once
 def migrate_data(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     for user in User.objects.all():  # OOM on large tables!
@@ -743,7 +743,7 @@ def migrate_data(apps, schema_editor):
 ### Safe Pattern
 
 ```python
-# ✅ Process in batches
+# Process in batches
 def migrate_data(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     batch_size = 1000
@@ -765,7 +765,7 @@ def migrate_data(apps, schema_editor):
 Or use `.iterator()`:
 
 ```python
-# ✅ Uses server-side cursor
+# Uses server-side cursor
 def migrate_data(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     for user in User.objects.all().iterator(chunk_size=1000):

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -131,10 +131,10 @@ Check Django migrations................................................Failed
 
 Found 1 migration issue(s):
 
-✖ ERROR [SM001] myapp/migrations/0002_add_field.py
+ERROR [SM001] myapp/migrations/0002_add_field.py
    Adding NOT NULL field 'email' without a default value
 
-   💡 Suggestion:
+   Suggestion:
       Add the field as nullable first, then backfill, then add NOT NULL.
 ```
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -30,7 +30,7 @@ You can also use the hook directly from the repository:
 ```yaml
 repos:
   - repo: https://github.com/YasserShkeir/django-safe-migrations
-    rev: v0.2.0  # Use the latest version
+    rev: v0.6.1  # Use the latest version
     hooks:
       - id: check-migrations
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,10 +30,10 @@ If you have any unsafe migrations, you'll see output like:
 ```
 Found 1 migration issue(s):
 
-✖ ERROR [SM001] myapp/migrations/0002_add_email.py:15
+ERROR [SM001] myapp/migrations/0002_add_email.py:15
    Adding NOT NULL field 'email' to 'user' without a default value will lock the table
 
-   💡 Suggestion:
+   Suggestion:
       Safe pattern for adding NOT NULL field:
       1. Add field as nullable
       2. Backfill existing rows in batches

--- a/docs/roadmap/v0.5.0.md
+++ b/docs/roadmap/v0.5.0.md
@@ -71,13 +71,13 @@ def get_old_field(migration, operation):
 
 ### Reporter Fixes
 
-| Issue                 | Reporter | Description                                                                           | Status |
-| --------------------- | -------- | ------------------------------------------------------------------------------------- | ------ |
-| SARIF helpUri 404s    | SARIF    | `helpUri` points to `/rules/SM001/` on readthedocs — pages likely don't exist         | Done   |
-| SARIF absolute paths  | SARIF    | `file_path` is absolute; GitHub Code Scanning expects relative paths from `%SRCROOT%` | Done   |
-| Console Unicode crash | Console  | `"✖"`, `"⚠"`, `"💡"` symbols crash on non-UTF-8 terminals (e.g., Windows cp1252)      | Done   |
-| GitHub title escaping | GitHub   | `issue.operation` used in title without escaping `%`, `\n`, `\r`                      | Done   |
-| JSON summary DRY      | JSON     | `_get_summary()` duplicates logic from `MigrationAnalyzer.get_summary()`              | Done   |
+| Issue                 | Reporter | Description                                                                                           | Status |
+| --------------------- | -------- | ----------------------------------------------------------------------------------------------------- | ------ |
+| SARIF helpUri 404s    | SARIF    | `helpUri` points to `/rules/SM001/` on readthedocs — pages likely don't exist                         | Done   |
+| SARIF absolute paths  | SARIF    | `file_path` is absolute; GitHub Code Scanning expects relative paths from `%SRCROOT%`                 | Done   |
+| Console Unicode crash | Console  | Unicode status symbols (cross/warning/light-bulb) crash on non-UTF-8 terminals (e.g., Windows cp1252) | Done   |
+| GitHub title escaping | GitHub   | `issue.operation` used in title without escaping `%`, `\n`, `\r`                                      | Done   |
+| JSON summary DRY      | JSON     | `_get_summary()` duplicates logic from `MigrationAnalyzer.get_summary()`                              | Done   |
 
 ### Test Quality
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -314,7 +314,7 @@ ______________________________________________________________________
 
 **Severity:** WARNING
 
-**Databases:** All
+**Databases:** PostgreSQL
 
 ### What it detects
 
@@ -387,7 +387,7 @@ ______________________________________________________________________
 Renaming a column:
 
 ```python
-# ℹ INFO
+# INFO
 migrations.RenameField(
     model_name='user',
     old_name='username',
@@ -485,7 +485,7 @@ ______________________________________________________________________
 RunPython data migrations:
 
 ```python
-# ℹ INFO
+# INFO
 def update_all_users(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     for user in User.objects.all():
@@ -632,7 +632,7 @@ ______________________________________________________________________
 
 **Severity:** ERROR
 
-**Databases:** All (especially PostgreSQL)
+**Databases:** Non-PostgreSQL (on PostgreSQL, the more specific [SM011](#sm011-non-concurrent-unique-constraint) takes over)
 
 ### What it detects
 
@@ -1047,7 +1047,7 @@ ______________________________________________________________________
 
 **Severity:** ERROR
 
-**Databases:** All
+**Databases:** PostgreSQL
 
 ### What it detects
 
@@ -1443,11 +1443,11 @@ ______________________________________________________________________
 
 ### What it detects
 
-`AddField` or `CreateModel` using `AutoField`, `SmallAutoField`, or `IntegerField` as a primary key. These 32-bit integer types max out at ~2.1 billion rows.
+`AddField` or `CreateModel` using `AutoField` or `SmallAutoField` as a primary key. These 32-bit integer types max out at ~2.1 billion rows.
 
 ### Why it's dangerous
 
-Once a 32-bit primary key overflows, inserts fail with `IntegerError`. Migrating a large table from `AutoField` to `BigAutoField` requires a full table rewrite with an ACCESS EXCLUSIVE lock.
+Once a 32-bit primary key overflows, inserts fail with an "integer out of range" error (`DataError`). Migrating a large table from `AutoField` to `BigAutoField` requires a full table rewrite with an ACCESS EXCLUSIVE lock.
 
 ### Safe pattern
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,7 +23,7 @@ ______________________________________________________________________
 Adding a `NOT NULL` column without a default value:
 
 ```python
-# ❌ UNSAFE
+# UNSAFE
 migrations.AddField(
     model_name='user',
     name='email',
@@ -44,7 +44,7 @@ For large tables, this can take **minutes to hours**.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Three-step process
+# SAFE: Three-step process
 
 # Migration 1: Add nullable column
 migrations.AddField(
@@ -85,7 +85,7 @@ ______________________________________________________________________
 Dropping a column that may still be referenced by running code:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.RemoveField(
     model_name='user',
     name='legacy_field',
@@ -121,7 +121,7 @@ ______________________________________________________________________
 Dropping a table (model) that may still be referenced:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.DeleteModel(name='LegacyModel')
 ```
 
@@ -152,7 +152,7 @@ ______________________________________________________________________
 Creating an index without using `CONCURRENTLY`:
 
 ```python
-# ❌ UNSAFE on PostgreSQL
+# UNSAFE on PostgreSQL
 migrations.AddIndex(
     model_name='user',
     index=models.Index(fields=['email'], name='user_email_idx'),
@@ -171,7 +171,7 @@ For large tables, this can take **minutes to hours** of write downtime.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use concurrent index
+# SAFE: Use concurrent index
 from django.contrib.postgres.operations import AddIndexConcurrently
 
 class Migration(migrations.Migration):
@@ -202,7 +202,7 @@ ______________________________________________________________________
 Adding a unique constraint without using a concurrent index:
 
 ```python
-# ❌ UNSAFE on PostgreSQL
+# UNSAFE on PostgreSQL
 migrations.AddConstraint(
     model_name='user',
     constraint=models.UniqueConstraint(
@@ -222,7 +222,7 @@ PostgreSQL implements unique constraints using indexes. Adding one:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Two-step process
+# SAFE: Two-step process
 
 # Migration 1: Create unique index concurrently
 from django.contrib.postgres.operations import AddIndexConcurrently
@@ -264,7 +264,7 @@ ______________________________________________________________________
 Changing a column's type via AlterField:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.AlterField(
     model_name='product',
     name='price',
@@ -285,7 +285,7 @@ Even seemingly safe changes (like `Integer` → `BigInteger`) can trigger full t
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Expand/Contract pattern
+# SAFE: Expand/Contract pattern
 
 # Migration 1: Add new column
 migrations.AddField(
@@ -321,7 +321,7 @@ ______________________________________________________________________
 Adding a ForeignKey that validates existing rows:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.AddField(
     model_name='article',
     name='author',
@@ -343,7 +343,7 @@ Adding a FK constraint:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Add FK without constraint validation
+# SAFE: Add FK without constraint validation
 
 # Migration 1: Add FK without database constraint
 migrations.AddField(
@@ -387,7 +387,7 @@ ______________________________________________________________________
 Renaming a column:
 
 ```python
-# ℹ️ INFO
+# ℹ INFO
 migrations.RenameField(
     model_name='user',
     old_name='username',
@@ -408,7 +408,7 @@ During a rolling deployment:
 For zero-downtime deployments:
 
 ```python
-# ✅ SAFE: Expand/Contract pattern
+# SAFE: Expand/Contract pattern
 
 # Migration 1: Add new column
 migrations.AddField(
@@ -441,7 +441,7 @@ ______________________________________________________________________
 RunSQL operations without reverse_sql:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.RunSQL(
     sql='CREATE INDEX idx_user_email ON users (email)',
 )
@@ -458,7 +458,7 @@ Without `reverse_sql`:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Always provide reverse_sql
+# SAFE: Always provide reverse_sql
 
 migrations.RunSQL(
     sql='CREATE INDEX idx_user_email ON users (email)',
@@ -485,7 +485,7 @@ ______________________________________________________________________
 RunPython data migrations:
 
 ```python
-# ℹ️ INFO
+# ℹ INFO
 def update_all_users(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     for user in User.objects.all():
@@ -507,7 +507,7 @@ Data migrations can be slow because:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Batch processing with iterator
+# SAFE: Batch processing with iterator
 
 def update_all_users(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
@@ -543,7 +543,7 @@ ______________________________________________________________________
 Adding a value to an enum type inside a transaction:
 
 ```python
-# ❌ UNSAFE on PostgreSQL
+# UNSAFE on PostgreSQL
 migrations.RunSQL(
     sql="ALTER TYPE status_enum ADD VALUE 'pending'",
 )
@@ -560,7 +560,7 @@ ERROR: ALTER TYPE ... ADD VALUE cannot run inside a transaction block
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Set atomic = False
+# SAFE: Set atomic = False
 
 class Migration(migrations.Migration):
     atomic = False  # Required for ALTER TYPE ADD VALUE
@@ -590,7 +590,7 @@ ______________________________________________________________________
 Decreasing the max_length of a CharField:
 
 ```python
-# ⚠️ WARNING - if max_length is being decreased
+# WARNING - if max_length is being decreased
 migrations.AlterField(
     model_name='user',
     name='username',
@@ -610,7 +610,7 @@ The database must verify all existing data fits within the new length.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use a CHECK constraint instead
+# SAFE: Use a CHECK constraint instead
 
 # Migration 1: Add CHECK constraint (doesn't rewrite table)
 migrations.RunSQL(
@@ -639,7 +639,7 @@ ______________________________________________________________________
 Adding a unique constraint to an existing table:
 
 ```python
-# ❌ UNSAFE
+# UNSAFE
 migrations.AddConstraint(
     model_name='user',
     constraint=models.UniqueConstraint(
@@ -661,7 +661,7 @@ For large tables, this can take minutes to hours.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Create index concurrently first
+# SAFE: Create index concurrently first
 
 # Migration 1: Create unique index concurrently
 from django.contrib.postgres.operations import AddIndexConcurrently
@@ -702,7 +702,7 @@ ______________________________________________________________________
 Renaming a model (which renames the database table):
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.RenameModel(
     old_name='OldUser',
     new_name='NewUser',
@@ -721,7 +721,7 @@ Renaming a model can cause:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Keep the old table name
+# SAFE: Keep the old table name
 
 class NewUser(models.Model):
     # ... fields ...
@@ -750,7 +750,7 @@ ______________________________________________________________________
 Using the deprecated `AlterUniqueTogether` operation:
 
 ```python
-# ⚠️ WARNING - deprecated
+# WARNING - deprecated
 migrations.AlterUniqueTogether(
     name='user',
     unique_together={('email', 'tenant_id')},
@@ -768,7 +768,7 @@ migrations.AlterUniqueTogether(
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use UniqueConstraint instead
+# SAFE: Use UniqueConstraint instead
 migrations.AddConstraint(
     model_name='user',
     constraint=models.UniqueConstraint(
@@ -797,7 +797,7 @@ ______________________________________________________________________
 `RunPython` operations without a `reverse_code` function:
 
 ```python
-# ⚠️ INFO
+# INFO
 migrations.RunPython(populate_defaults)  # No reverse_code
 ```
 
@@ -812,7 +812,7 @@ Without `reverse_code`, the migration cannot be rolled back. If something goes w
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Always provide reverse_code
+# SAFE: Always provide reverse_code
 
 def populate_defaults(apps, schema_editor):
     Model = apps.get_model('app', 'Model')
@@ -847,7 +847,7 @@ ______________________________________________________________________
 Adding a check constraint to an existing table:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.AddConstraint(
     model_name='order',
     constraint=models.CheckConstraint(
@@ -868,7 +868,7 @@ Adding a check constraint requires PostgreSQL to validate ALL existing rows agai
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Add as NOT VALID first, then validate
+# SAFE: Add as NOT VALID first, then validate
 
 # Migration 1: Add constraint as NOT VALID
 migrations.RunSQL(
@@ -908,7 +908,7 @@ Using `AddIndexConcurrently` or `RemoveIndexConcurrently` in a migration without
 `atomic = False`:
 
 ```python
-# ⚠️ ERROR
+# ERROR
 class Migration(migrations.Migration):
     # Missing atomic = False!
     operations = [
@@ -931,7 +931,7 @@ CREATE INDEX CONCURRENTLY cannot run inside a transaction block
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Set atomic = False
+# SAFE: Set atomic = False
 class Migration(migrations.Migration):
     atomic = False
 
@@ -956,7 +956,7 @@ ______________________________________________________________________
 Using SQL reserved keywords as column names:
 
 ```python
-# ⚠️ INFO
+# INFO
 migrations.AddField(
     model_name='product',
     name='order',  # 'order' is a SQL keyword
@@ -979,7 +979,7 @@ Common problematic names: `order`, `user`, `group`, `select`, `table`, `index`,
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use descriptive, non-reserved names
+# SAFE: Use descriptive, non-reserved names
 migrations.AddField(
     model_name='product',
     name='sort_order',  # Descriptive and not reserved
@@ -1001,7 +1001,7 @@ Changing a field from `null=True` to `null=False` without ensuring existing NULL
 values are handled:
 
 ```python
-# ⚠️ ERROR
+# ERROR
 migrations.AlterField(
     model_name='user',
     name='email',
@@ -1024,7 +1024,7 @@ rows.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Backfill NULLs first, then alter
+# SAFE: Backfill NULLs first, then alter
 
 # Migration 1: Backfill NULL values
 def backfill_emails(apps, schema_editor):
@@ -1054,7 +1054,7 @@ ______________________________________________________________________
 Adding a UNIQUE constraint via `AlterField`:
 
 ```python
-# ⚠️ ERROR
+# ERROR
 migrations.AlterField(
     model_name='user',
     name='email',
@@ -1072,7 +1072,7 @@ migrations.AlterField(
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use concurrent index (PostgreSQL)
+# SAFE: Use concurrent index (PostgreSQL)
 
 # Migration 1: Create unique index concurrently
 class Migration(migrations.Migration):
@@ -1112,7 +1112,7 @@ ______________________________________________________________________
 Using potentially expensive callables as field defaults:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.AddField(
     model_name='event',
     name='created_at',
@@ -1132,7 +1132,7 @@ When adding a column with a default, some databases:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use database-level defaults or backfill
+# SAFE: Use database-level defaults or backfill
 
 # Option 1: Use auto_now_add (handled at ORM level)
 field=models.DateTimeField(auto_now_add=True, null=True)
@@ -1167,7 +1167,7 @@ ______________________________________________________________________
 Adding a ManyToMany field:
 
 ```python
-# ⚠️ INFO
+# INFO
 migrations.AddField(
     model_name='article',
     name='tags',
@@ -1190,7 +1190,7 @@ implications.
 ### Best practices
 
 ```python
-# ✅ Consider: Add the field, but populate data carefully
+# Consider: Add the field, but populate data carefully
 
 # The migration (safe):
 migrations.AddField(
@@ -1226,7 +1226,7 @@ ______________________________________________________________________
 Potential SQL injection patterns in `RunSQL` operations:
 
 ```python
-# ⚠️ ERROR
+# ERROR
 table_name = "users"  # Could come from untrusted source
 migrations.RunSQL(
     sql=f"DROP TABLE {table_name}",  # String formatting = injection risk
@@ -1251,7 +1251,7 @@ in migrations can:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use hardcoded SQL or Django's schema editor
+# SAFE: Use hardcoded SQL or Django's schema editor
 
 # Option 1: Hardcoded SQL (when you control the values)
 migrations.RunSQL(
@@ -1280,7 +1280,7 @@ ______________________________________________________________________
 Adding a ForeignKey without `db_index=True` (or when `db_index=False`):
 
 ```python
-# ⚠️ WARNING
+# WARNING
 migrations.AddField(
     model_name='order',
     name='customer',
@@ -1307,7 +1307,7 @@ rule catches when you explicitly disable it.
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Keep the default index (or explicitly enable)
+# SAFE: Keep the default index (or explicitly enable)
 migrations.AddField(
     model_name='order',
     name='customer',
@@ -1332,7 +1332,7 @@ ______________________________________________________________________
 `RunPython` operations that use `.all()` without batching:
 
 ```python
-# ⚠️ WARNING
+# WARNING
 def migrate_data(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
     for user in User.objects.all():  # Loads ALL users into memory!
@@ -1354,7 +1354,7 @@ Loading all rows into memory:
 ### Safe pattern
 
 ```python
-# ✅ SAFE: Use batching with iterator() or chunked updates
+# SAFE: Use batching with iterator() or chunked updates
 
 def migrate_data(apps, schema_editor):
     User = apps.get_model('myapp', 'User')
@@ -1414,7 +1414,7 @@ branches.
 ### Safe pattern
 
 ```bash
-# ✅ SAFE: Create a merge migration
+# SAFE: Create a merge migration
 python manage.py makemigrations --merge myapp
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,6 +90,7 @@ WARNING: Unknown category 'destrutive' in DISABLED_CATEGORIES. Did you mean 'des
 - `locking`, `data-loss`, `reversibility`, `data-migrations`
 - `high-risk`, `informational`, `naming`, `schema-changes`
 - `relations`, `security`, `performance`
+- `mysql`, `sqlite` (currently empty placeholders, but valid names)
 
 ### Rules Not Being Detected
 
@@ -175,7 +176,7 @@ python manage.py check_migrations myapp --format=json
 
 ```bash
 # Using Docker
-docker-compose -f docker-compose.test.yml up test-py313
+docker compose -f docker-compose.test.yml up test-py313
 ```
 
 ### MySQL Compatibility


### PR DESCRIPTION
## Docs: emoji cleanup + full accuracy review

Two commits.

### 1. Remove emojis from documentation (`736f147`)
Stripped all 183 emoji occurrences across README, TESTING, and `docs/*` (10 files). Semantic markers became text (`Safe`/`Unsafe`, `Yes`/`No`, severity labels); console-output example glyphs were dropped; typographic arrows `→` were kept. The box-drawing matrix was re-aligned and one quoted-literal case in the v0.5.0 roadmap was reworded rather than blanked.

### 2. Fix accuracy issues from a full docs review (`04a2071`)
A per-file audit of every doc against the v0.6.1 code surfaced 59 issues (16 high, 20 medium, 23 low); ~50 are fixed here:

- **Support matrices** (README, `docs/django-compatibility.md`, `TESTING.md`): added Python 3.14 and Django 6.0 with the correct CI exclusions (Django 6.0 → Python 3.12+; Python 3.14 → Django 6.0 only).
- **PostgreSQL-only rules**: all 11 (SM005, SM010–013, SM017, SM018, SM021, SM030, SM031, SM034) now documented consistently; SM005/SM021 were wrongly marked "All".
- **`docs/architecture.md`**: corrected class names (`JsonReporter`/`SarifReporter`), `get_config()`, `list[str]` return types, the `reporters/` package layout, the `MigrationAnalyzer` constructor, and the rule→file mapping.
- **`docs/configuration.md`**: regenerated the `DISABLED_CATEGORIES` table from `conf.py` (added `mysql`/`sqlite`/`relations`/`security`/`performance`) and documented `--output/-o`.
- **SM028**: only detects `AutoField`/`SmallAutoField` (not `IntegerField`); fixed `docs/rules.md` and removed a bogus `IntegerError` reference.
- **`docs/detected-patterns.md`**: fixed the broken `rules/index.md` link and switched examples to real `testapp/migrations` filenames.
- **`TESTING.md`**: fixed make targets, synced the embedded `tox.ini`/`docker-compose`/`ci.yml` snippets, dropped nonexistent `tests/database`/`tests/e2e` references, fixed a placeholder issue URL.
- Bumped stale version refs (pre-commit `rev`, SARIF/`helpUri` examples) to 0.6.1; fixed the stale `--help` sample and JSON-output example shapes; stripped two leftover `ℹ` glyphs the emoji pass missed.

### Verification
- 0 emoji/symbols remain across all source markdown (broadened scan incl. letterlike symbols)
- 0 broken relative `.md` links
- `mdformat` + `markdownlint` pass
- Compatibility matrix and category table verified to exactly match `ci.yml` and `conf.py`

> Note (follow-up, not fixed here): the code itself has a latent inconsistency — SM017 is PostgreSQL-only via `db_vendors` but is missing from `conf.py`'s `postgresql` *category*. The docs now faithfully reflect the code as-is; reconciling that is a separate code change.
