### PR TITLE
fix: rule-accuracy improvements (SM004, SM012, SM022, SM024, SM028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SM004**: stop flagging a `CharField` `max_length` *increase* as a table
+  rewrite (it is metadata-only on PostgreSQL), and start flagging
+  `db_collation` and `db_index` changes, which do rewrite/lock the table.
+- **SM012**: detect `ALTER TYPE ... ADD VALUE` when the enum type name is
+  schema-qualified (`myschema.my_enum`) or double-quoted (`"My Enum"`).
+- **SM022**: flag `datetime.date.today` as an expensive per-row default
+  (its bare `__name__` is `today`, which was missing from the slow-callable
+  list).
+- **SM024**: the fix suggestion no longer recommends `migrations.RunSQL(...,
+  params=...)`, which raises `TypeError` because `RunSQL` has no `params`
+  argument; it now points to `RunPython` with a parameterized cursor.
+
+### Changed
+
+- **SM028**: now also detects 32-bit `IntegerField` and `SmallIntegerField`
+  primary keys (previously only `AutoField`/`SmallAutoField`), matching the
+  rule's stated intent.
+- Add `SM017` to the `postgresql` rule category (it is PostgreSQL-only via
+  `db_vendors` but was missing from the category map).
+
 ## [0.6.1] - 2026-06-03
 
 ### Fixed

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -61,6 +61,7 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM011",
         "SM012",
         "SM013",
+        "SM017",
         "SM018",
         "SM021",
         "SM030",

--- a/django_safe_migrations/rules/add_field.py
+++ b/django_safe_migrations/rules/add_field.py
@@ -188,6 +188,7 @@ class ExpensiveDefaultCallableRule(BaseRule):
             "datetime.datetime.now",
             "timezone.now",
             "django.utils.timezone.now",
+            "today",
             "date.today",
             "datetime.date.today",
         }
@@ -318,11 +319,12 @@ If exact timestamp isn't required, use a static value:
 
 
 class PreferBigIntRule(BaseRule):
-    """Detect AutoField or IntegerField used as primary key.
+    """Detect a 32-bit integer field used as a primary key.
 
-    32-bit integer primary keys (AutoField, IntegerField with primary_key=True)
-    can overflow at ~2.1 billion rows. For new tables, BigAutoField or
-    BigIntegerField should be preferred to avoid costly future migrations.
+    32-bit primary keys (AutoField, SmallAutoField, IntegerField, or
+    SmallIntegerField with primary_key=True) can overflow at ~2.1 billion
+    rows. For new tables, BigAutoField or BigIntegerField should be preferred
+    to avoid costly future migrations.
 
     Safe pattern:
     Use BigAutoField or BigIntegerField for primary keys, or set
@@ -333,11 +335,13 @@ class PreferBigIntRule(BaseRule):
     severity = Severity.WARNING
     description = "Prefer BigAutoField/BigIntegerField over 32-bit primary keys"
 
-    # 32-bit auto/int field types that may overflow
+    # 32-bit auto/int field types that may overflow as primary keys
     SMALL_PK_TYPES = frozenset(
         {
             "AutoField",
             "SmallAutoField",
+            "IntegerField",
+            "SmallIntegerField",
         }
     )
 
@@ -370,7 +374,8 @@ class PreferBigIntRule(BaseRule):
                     message=(
                         f"Field '{operation.name}' on '{operation.model_name}' "
                         f"uses {field_type} as primary key. Consider using "
-                        "BigAutoField to avoid overflow at ~2.1 billion rows."
+                        "BigAutoField/BigIntegerField to avoid overflow "
+                        "at ~2.1 billion rows."
                     ),
                 )
 
@@ -388,7 +393,8 @@ class PreferBigIntRule(BaseRule):
                         message=(
                             f"Field '{field_name}' on '{model_name}' uses "
                             f"{field_type} as primary key. Consider using "
-                            "BigAutoField to avoid overflow at ~2.1 billion rows."
+                            "BigAutoField/BigIntegerField to avoid overflow "
+                            "at ~2.1 billion rows."
                         ),
                     )
 

--- a/django_safe_migrations/rules/alter_field.py
+++ b/django_safe_migrations/rules/alter_field.py
@@ -45,21 +45,6 @@ class AlterColumnTypeRule(BaseRule):
     severity = Severity.WARNING
     description = "Changing column type may rewrite table and lock it"
 
-    # Attributes that are metadata-only and don't affect the database schema
-    METADATA_ONLY_ATTRIBUTES = frozenset(
-        {
-            "verbose_name",
-            "help_text",
-            "error_messages",
-            "validators",
-            "choices",
-            "editable",
-            "serialize",
-            "blank",
-            "db_comment",
-        }
-    )
-
     def check(
         self,
         operation: Operation,
@@ -126,66 +111,38 @@ class AlterColumnTypeRule(BaseRule):
         old_type = old_field.__class__.__name__
         new_type = new_field.__class__.__name__
 
-        # Type change is potentially unsafe
+        # A change of field/column type is potentially a full table rewrite.
         if old_type != new_type:
             return False
 
-        # Same type — check if only metadata attributes changed
-        for attr in self.METADATA_ONLY_ATTRIBUTES:
-            old_val = getattr(old_field, attr, None)
-            new_val = getattr(new_field, attr, None)
-            if old_val != new_val:
-                logger.debug(
-                    "Metadata-only attribute '%s' changed: %s -> %s",
-                    attr,
-                    old_val,
-                    new_val,
-                )
+        # Changing the column collation rewrites the table on PostgreSQL.
+        old_collation = getattr(old_field, "db_collation", None)
+        new_collation = getattr(new_field, "db_collation", None)
+        if old_collation != new_collation:
+            return False
 
-        # Check if null changed (adding null=True is safe)
-        old_null = getattr(old_field, "null", False)
-        new_null = getattr(new_field, "null", False)
-        if old_null != new_null and new_null:
-            # Adding nullable — safe
-            return True
+        # Adding (or removing) db_index builds/drops an index, which locks.
+        old_index = getattr(old_field, "db_index", False)
+        new_index = getattr(new_field, "db_index", False)
+        if old_index != new_index:
+            return False
 
-        # Check if default changed (safe, metadata-only in PostgreSQL)
-        from django.db.models.fields import NOT_PROVIDED
-
-        old_default = getattr(old_field, "default", NOT_PROVIDED)
-        new_default = getattr(new_field, "default", NOT_PROVIDED)
-        if old_default != new_default and old_type == new_type:
-            # Changing default on same type is safe (no schema change)
-            # Check if anything else schema-affecting changed
-            old_null = getattr(old_field, "null", False)
-            new_null = getattr(new_field, "null", False)
-            old_max = getattr(old_field, "max_length", None)
-            new_max = getattr(new_field, "max_length", None)
-            old_unique = getattr(old_field, "unique", False)
-            new_unique = getattr(new_field, "unique", False)
-
-            if old_null == new_null and old_max == new_max and old_unique == new_unique:
-                return True
-
-        # Same type, no schema-affecting change detected
-        # Still check if there's a real schema change
-        old_null = getattr(old_field, "null", False)
-        new_null = getattr(new_field, "null", False)
-        old_max = getattr(old_field, "max_length", None)
-        new_max = getattr(new_field, "max_length", None)
+        # Adding a UNIQUE constraint requires a full scan/lock (see SM021).
         old_unique = getattr(old_field, "unique", False)
         new_unique = getattr(new_field, "unique", False)
+        if new_unique and not old_unique:
+            return False
 
-        if (
-            old_type == new_type
-            and old_null == new_null
-            and old_max == new_max
-            and old_unique == new_unique
-        ):
-            # No schema-affecting attributes changed — metadata only
-            return True
+        # max_length: increasing it is a metadata-only change on PostgreSQL,
+        # but decreasing it rewrites/validates the column (see SM013).
+        old_max = getattr(old_field, "max_length", None)
+        new_max = getattr(new_field, "max_length", None)
+        if old_max is not None and new_max is not None and new_max < old_max:
+            return False
 
-        return False
+        # Anything left (metadata, default, nullable, db_column, or a
+        # max_length increase) is a safe, non-rewriting change.
+        return True
 
     def _is_likely_safe_change(self, field: object) -> bool:
         """Fallback heuristic when old field state is unavailable.

--- a/django_safe_migrations/rules/run_sql.py
+++ b/django_safe_migrations/rules/run_sql.py
@@ -113,9 +113,10 @@ class EnumAddValueInTransactionRule(BaseRule):
     description = "Adding enum value in transaction will fail in PostgreSQL"
     db_vendors = ["postgresql"]
 
-    # Patterns that indicate adding enum value
+    # Patterns that indicate adding enum value. The type name may be
+    # schema-qualified (myschema.my_enum) or double-quoted ("My Enum").
     ENUM_ADD_PATTERNS = [
-        r"ALTER\s+TYPE\s+\w+\s+ADD\s+VALUE",
+        r'ALTER\s+TYPE\s+(?:"[^"]+"|[\w.]+)\s+ADD\s+VALUE',
     ]
 
     def check(
@@ -493,12 +494,17 @@ class SQLInjectionPatternRule(BaseRule):
    - Use identifier quoting for table/column names
    - Never interpolate user input directly
 
-4. If this warning is a false positive (e.g., you're using
-   params argument correctly), suppress it:
+   Note: migrations.RunSQL does NOT accept a `params` argument. To run a
+   parameterized query, use RunPython with a cursor instead:
+
+   def run(apps, schema_editor):
+       with schema_editor.connection.cursor() as cursor:
+           cursor.execute('UPDATE t SET c = %s WHERE id = %s', [value, pk])
+
+4. If this warning is a false positive, suppress it inline:
 
    migrations.RunSQL(  # safe-migrations: ignore SM024
-       sql='SELECT * FROM %(table)s',
-       params={'table': 'users'},
+       sql="UPDATE t SET ratio = paid / total * 100",
    )
 """
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ Disable entire categories of rules at once. Available categories:
 
 | Category          | Description               | Rules                                                                                            |
 | ----------------- | ------------------------- | ------------------------------------------------------------------------------------------------ |
-| `postgresql`      | PostgreSQL-specific rules | SM005, SM010, SM011, SM012, SM013, SM018, SM021, SM030, SM031, SM034                             |
+| `postgresql`      | PostgreSQL-specific rules | SM005, SM010, SM011, SM012, SM013, SM017, SM018, SM021, SM030, SM031, SM034                      |
 | `mysql`           | MySQL-specific rules      | (none currently)                                                                                 |
 | `sqlite`          | SQLite-specific rules     | (none currently)                                                                                 |
 | `indexes`         | Index-related operations  | SM010, SM011, SM018, SM021, SM030                                                                |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1443,7 +1443,7 @@ ______________________________________________________________________
 
 ### What it detects
 
-`AddField` or `CreateModel` using `AutoField` or `SmallAutoField` as a primary key. These 32-bit integer types max out at ~2.1 billion rows.
+`AddField` or `CreateModel` using `AutoField`, `SmallAutoField`, `IntegerField`, or `SmallIntegerField` as a primary key. These 32-bit integer types max out at ~2.1 billion rows.
 
 ### Why it's dangerous
 

--- a/tests/unit/rules/test_add_field_rules.py
+++ b/tests/unit/rules/test_add_field_rules.py
@@ -266,6 +266,23 @@ class TestExpensiveDefaultCallableRule:
         assert issue is not None
         assert issue.rule_id == "SM022"
 
+    def test_flags_date_today_callable(self, mock_migration):
+        """SM022 flags datetime.date.today (its bare __name__ is 'today')."""
+        import datetime
+
+        from django_safe_migrations.rules.add_field import ExpensiveDefaultCallableRule
+
+        rule = ExpensiveDefaultCallableRule()
+        operation = migrations.AddField(
+            model_name="article",
+            name="published_on",
+            field=models.DateField(default=datetime.date.today),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM022"
+
 
 class TestNotNullWithoutDefaultRuleUUIDField:
     """Tests for SM001 UUIDField handling (v0.5.0 fix).
@@ -492,6 +509,63 @@ class TestPreferBigIntRule:
 
         assert suggestion is not None
         assert "BigAutoField" in suggestion
+
+    def test_detects_integerfield_pk(self, mock_migration):
+        """Test that rule detects a 32-bit IntegerField primary key."""
+        from django_safe_migrations.rules.add_field import PreferBigIntRule
+
+        rule = PreferBigIntRule()
+        operation = migrations.AddField(
+            model_name="user",
+            name="legacy_id",
+            field=models.IntegerField(primary_key=True),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM028"
+        assert "IntegerField" in issue.message
+
+    def test_detects_smallintegerfield_pk(self, mock_migration):
+        """Test that rule detects a SmallIntegerField primary key."""
+        from django_safe_migrations.rules.add_field import PreferBigIntRule
+
+        rule = PreferBigIntRule()
+        operation = migrations.AddField(
+            model_name="order",
+            name="legacy_id",
+            field=models.SmallIntegerField(primary_key=True),
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM028"
+
+    def test_ignores_integerfield_not_pk(self, mock_migration):
+        """Test that a non-primary-key IntegerField is not flagged."""
+        from django_safe_migrations.rules.add_field import PreferBigIntRule
+
+        rule = PreferBigIntRule()
+        operation = migrations.AddField(
+            model_name="user",
+            name="count",
+            field=models.IntegerField(default=0),
+        )
+
+        assert rule.check(operation, mock_migration) is None
+
+    def test_allows_bigintegerfield_pk(self, mock_migration):
+        """Test that a 64-bit BigIntegerField primary key is allowed."""
+        from django_safe_migrations.rules.add_field import PreferBigIntRule
+
+        rule = PreferBigIntRule()
+        operation = migrations.AddField(
+            model_name="user",
+            name="id",
+            field=models.BigIntegerField(primary_key=True),
+        )
+
+        assert rule.check(operation, mock_migration) is None
 
 
 class TestPreferTextOverVarcharRule:

--- a/tests/unit/rules/test_alter_field_rules.py
+++ b/tests/unit/rules/test_alter_field_rules.py
@@ -201,6 +201,43 @@ class TestAlterColumnTypeRuleWithOldField:
         assert issue is not None
         assert issue.rule_id == "SM004"
 
+    def test_safe_when_max_length_increased(self, mock_migration):
+        """Increasing CharField max_length is metadata-only (safe)."""
+        rule = AlterColumnTypeRule()
+        old_field = models.CharField(max_length=50)
+        new_field = models.CharField(max_length=255)
+        operation = migrations.AlterField(
+            model_name="user", name="name", field=new_field
+        )
+
+        assert rule.check(operation, mock_migration, old_field=old_field) is None
+
+    def test_unsafe_when_db_collation_changed(self, mock_migration):
+        """Changing db_collation rewrites the table on PostgreSQL (unsafe)."""
+        rule = AlterColumnTypeRule()
+        old_field = models.CharField(max_length=100)
+        new_field = models.CharField(max_length=100, db_collation="en-x-icu")
+        operation = migrations.AlterField(
+            model_name="user", name="name", field=new_field
+        )
+        issue = rule.check(operation, mock_migration, old_field=old_field)
+
+        assert issue is not None
+        assert issue.rule_id == "SM004"
+
+    def test_unsafe_when_db_index_added(self, mock_migration):
+        """Adding db_index builds an index and is not a no-op (unsafe)."""
+        rule = AlterColumnTypeRule()
+        old_field = models.CharField(max_length=100)
+        new_field = models.CharField(max_length=100, db_index=True)
+        operation = migrations.AlterField(
+            model_name="user", name="name", field=new_field
+        )
+        issue = rule.check(operation, mock_migration, old_field=old_field)
+
+        assert issue is not None
+        assert issue.rule_id == "SM004"
+
 
 class TestAlterVarcharLengthRuleWithOldField:
     """Tests for SM013 with old_field comparison."""

--- a/tests/unit/rules/test_run_sql_rules.py
+++ b/tests/unit/rules/test_run_sql_rules.py
@@ -157,6 +157,30 @@ class TestEnumAddValueInTransactionRule:
         assert issue is not None
         assert issue.rule_id == "SM012"
 
+    def test_detects_schema_qualified_enum(self, mock_migration):
+        """SM012 detects a schema-qualified enum type name."""
+        rule = EnumAddValueInTransactionRule()
+        operation = migrations.RunSQL(
+            sql="ALTER TYPE myschema.my_enum ADD VALUE 'new_entry'",
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM012"
+
+    def test_detects_quoted_enum(self, mock_migration):
+        """SM012 detects a double-quoted enum type name."""
+        rule = EnumAddValueInTransactionRule()
+        operation = migrations.RunSQL(
+            sql="ALTER TYPE \"My Enum\" ADD VALUE 'new_entry'",
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM012"
+
 
 class TestLargeDataMigrationRule:
     """Tests for LargeDataMigrationRule (SM008)."""


### PR DESCRIPTION
## Rule-accuracy improvements

Fixes false positives / false negatives in five rules surfaced by the audit, plus a category-map inconsistency. Each change has regression tests; full suite is 701 passing.

### Fixed
- **SM004** (`alter_column_type`)
  - **FP**: no longer flags a `CharField` `max_length` *increase* — that's a metadata-only change on PostgreSQL.
  - **FN**: now flags `db_collation` changes (table rewrite) and `db_index` add/remove (index build, locking), which were previously treated as safe.
  - Removes the now-unused `METADATA_ONLY_ATTRIBUTES` dead code.
- **SM012** (`enum_add_value_transaction`): matches `ALTER TYPE ... ADD VALUE` when the enum type name is schema-qualified (`myschema.my_enum`) or double-quoted (`"My Enum"`), not just a bare identifier.
- **SM022** (`expensive_default_callable`): flags `datetime.date.today` — its runtime `__name__` is the bare `today` (with `__module__` `None`), which was missing from the slow-callable list.
- **SM024** (`sql_injection_pattern`): the fix suggestion no longer recommends `migrations.RunSQL(..., params=...)`, which raises `TypeError` (`RunSQL` has no `params` argument); it now points to `RunPython` with a parameterized cursor.

### Changed
- **SM028** (`prefer_bigint_over_int`): now also detects 32-bit `IntegerField` and `SmallIntegerField` primary keys (previously only `AutoField`/`SmallAutoField`), matching the rule's stated intent; message suggests `BigAutoField`/`BigIntegerField`.
- Adds `SM017` to the `postgresql` rule **category** — it is PostgreSQL-only via `db_vendors` but was missing from the category map, so `ENABLED_CATEGORIES=["postgresql"]` / `DISABLED_CATEGORIES=["postgresql"]` didn't include it.

### Tests & docs
- 10 new regression tests across `test_alter_field_rules.py`, `test_add_field_rules.py`, `test_run_sql_rules.py`.
- Updated `docs/rules.md` (SM028 detected types), `docs/configuration.md` (postgresql category), and `CHANGELOG.md`.
