### PR TITLE
fix: harden reporters (SARIF/GitHub/GitLab) and PyPI publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,39 @@ on:
       - "v*"
 
 jobs:
+  test:
+    name: Test before publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION="$(python -c 'import django_safe_migrations as m; print(m.__version__)')"
+          echo "Tag version: $TAG_VERSION / package version: $PKG_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match package __version__ $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: pytest tests/
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    needs: test # Do not publish if tests or the version check fail
     environment:
       name: pypi
       url: https://pypi.org/p/django-safe-migrations
@@ -27,10 +57,13 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build twine
 
       - name: Build package
         run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SM024**: the fix suggestion no longer recommends `migrations.RunSQL(...,
   params=...)`, which raises `TypeError` because `RunSQL` has no `params`
   argument; it now points to `RunPython` with a parameterized cursor.
+- **SARIF reporter**: emit forward-slashed, repository-root-relative artifact
+  URIs and drop the undeclared `%SRCROOT%` `uriBaseId`, which is invalid SARIF
+  that GitHub Code Scanning rejects.
+- **GitHub reporter**: escape `:` and `,` (in addition to `%`/`\r`/`\n`) in the
+  `file=` and `title=` annotation properties, so paths/titles containing those
+  characters (e.g. a Windows drive path) no longer corrupt the workflow command.
+- **GitLab reporter**: include the line number and message in the Code Quality
+  fingerprint so two distinct findings on the same operation are no longer
+  given identical fingerprints (which made GitLab drop one).
 
 ### Changed
 
@@ -28,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rule's stated intent.
 - Add `SM017` to the `postgresql` rule category (it is PostgreSQL-only via
   `db_vendors` but was missing from the category map).
+- **Release pipeline**: the PyPI publish workflow now runs the test suite and
+  verifies the git tag matches `__version__` before publishing, and runs
+  `twine check` on the built artifacts. A tag no longer publishes to PyPI when
+  tests fail or the version is mismatched.
 
 ## [0.6.1] - 2026-06-03
 

--- a/django_safe_migrations/reporters/github.py
+++ b/django_safe_migrations/reporters/github.py
@@ -36,6 +36,24 @@ class GitHubReporter(BaseReporter):
         """
         super().__init__(stream or sys.stdout)
 
+    @staticmethod
+    def _escape_data(value: str) -> str:
+        r"""Escape a workflow-command message (the text after ``::``).
+
+        Per GitHub's spec, message data must escape ``%``, ``\r``, ``\n``.
+        """
+        return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+    @classmethod
+    def _escape_property(cls, value: str) -> str:
+        r"""Escape a workflow-command property value (e.g. ``file=``/``title=``).
+
+        Property values are comma-separated and colon-delimited, so in
+        addition to the message escapes they must also escape ``:`` and
+        ``,`` (otherwise a filename like ``C:\a,b`` corrupts the command).
+        """
+        return cls._escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
     def _format_annotation(self, issue: Issue) -> str:
         """Format an issue as a GitHub workflow command.
 
@@ -47,11 +65,11 @@ class GitHubReporter(BaseReporter):
         """
         command = self.SEVERITY_COMMANDS.get(issue.severity, "notice")
 
-        # Build parameters
+        # Build parameters (property values need the stricter escaping)
         params = []
 
         if issue.file_path:
-            params.append(f"file={issue.file_path}")
+            params.append(f"file={self._escape_property(issue.file_path)}")
         if issue.line_number:
             params.append(f"line={issue.line_number}")
 
@@ -60,18 +78,12 @@ class GitHubReporter(BaseReporter):
         if issue.operation:
             title_parts.append(str(issue.operation))
         title = " ".join(title_parts)
-        # Escape special characters in title
-        title = title.replace("%", "%25")
-        title = title.replace("\n", "%0A")
-        title = title.replace("\r", "%0D")
-        params.append(f"title={title}")
+        params.append(f"title={self._escape_property(title)}")
 
         params_str = ",".join(params)
 
-        # Message (escape special characters)
-        message = issue.message.replace("%", "%25")
-        message = message.replace("\n", "%0A")
-        message = message.replace("\r", "%0D")
+        # Message uses the data (non-property) escaping
+        message = self._escape_data(issue.message)
 
         return f"::{command} {params_str}::{message}"
 

--- a/django_safe_migrations/reporters/gitlab.py
+++ b/django_safe_migrations/reporters/gitlab.py
@@ -67,10 +67,13 @@ class GitLabReporter(BaseReporter):
         Returns:
             A dictionary in GitLab Code Quality format.
         """
-        # Build a stable fingerprint from the issue identity
+        # Build a stable fingerprint from the issue identity. Include the
+        # line number and message so that two distinct findings on the same
+        # operation (same rule/app/migration/operation) do not collide and
+        # get silently deduplicated by GitLab.
         fingerprint_source = (
-            f"{issue.rule_id}:{issue.app_label}:"
-            f"{issue.migration_name}:{issue.operation}"
+            f"{issue.rule_id}:{issue.app_label}:{issue.migration_name}:"
+            f"{issue.operation}:{issue.line_number}:{issue.message}"
         )
         fingerprint = hashlib.md5(  # noqa: S324  # nosec B324
             fingerprint_source.encode()

--- a/django_safe_migrations/reporters/sarif.py
+++ b/django_safe_migrations/reporters/sarif.py
@@ -102,6 +102,25 @@ class SarifReporter(BaseReporter):
         super().__init__(stream or sys.stdout)
         self.pretty = pretty
         self._tool_version = tool_version
+        self._base_dir: str | None = None
+
+    def _relative_uri(self, file_path: str) -> str:
+        """Return *file_path* as a forward-slashed, repo-root-relative URI.
+
+        GitHub Code Scanning resolves artifact URIs against the repository
+        root, so paths are made relative to the git root (falling back to the
+        current working directory). The git root is resolved once and cached.
+        """
+        if self._base_dir is None:
+            from django_safe_migrations.diff import _find_git_root
+
+            self._base_dir = _find_git_root()
+        try:
+            rel = os.path.relpath(file_path, self._base_dir)
+        except ValueError:
+            # On Windows, relpath fails across drives — keep the original.
+            rel = file_path
+        return rel.replace(os.sep, "/")
 
     @property
     def tool_version(self) -> str:
@@ -221,19 +240,16 @@ class SarifReporter(BaseReporter):
 
         # Add location if available
         if issue.file_path:
-            # Convert absolute paths to relative for GitHub Code Scanning
-            file_uri = issue.file_path
-            if os.path.isabs(file_uri):
-                try:
-                    file_uri = os.path.relpath(file_uri)
-                except ValueError:
-                    pass  # On Windows, relpath can fail across drives
+            # Emit a forward-slashed, repo-root-relative URI. No uriBaseId is
+            # set: GitHub Code Scanning resolves relative URIs against the repo
+            # root, and an undeclared uriBaseId (the old "%SRCROOT%") is invalid
+            # SARIF that GitHub rejects.
+            file_uri = self._relative_uri(issue.file_path)
 
             location: dict[str, Any] = {
                 "physicalLocation": {
                     "artifactLocation": {
                         "uri": file_uri,
-                        "uriBaseId": "%SRCROOT%",
                     }
                 }
             }

--- a/tests/unit/test_reporters.py
+++ b/tests/unit/test_reporters.py
@@ -306,6 +306,48 @@ class TestGitHubReporterEscaping:
         assert "title=[SM001]" in output
         assert "None" not in output.split("title=")[1].split("::")[0]
 
+    def test_escapes_comma_and_colon_in_property_values(self):
+        """Commas/colons in file and title properties must be escaped.
+
+        Otherwise a comma would be read as a parameter separator (and a
+        Windows drive colon would corrupt the command).
+        """
+        stream = StringIO()
+        reporter = GitHubReporter(stream=stream)
+        issue = Issue(
+            rule_id="SM024",
+            severity=Severity.ERROR,
+            operation="RunSQL(a,b)",
+            message="msg",
+            file_path="C:/proj/a,b/migrations/0001.py",
+            line_number=5,
+        )
+        output = reporter.report([issue])
+        line = next(line for line in output.splitlines() if line.startswith("::error"))
+        props = line.split("::")[1]  # the file=...,line=...,title=... segment
+
+        # Raw separators must not leak into property values
+        assert "a,b" not in props
+        assert "C:/proj" not in props
+        assert "%2C" in props  # escaped comma
+        assert "%3A" in props  # escaped colon
+        # Genuine delimiters are still present
+        assert "file=" in props and "line=5" in props and "title=" in props
+
+    def test_does_not_over_escape_message(self):
+        """The message (after ``::``) keeps ``:`` and ``,`` unescaped."""
+        stream = StringIO()
+        reporter = GitHubReporter(stream=stream)
+        issue = Issue(
+            rule_id="SM001",
+            severity=Severity.ERROR,
+            operation="AddField",
+            message="reserved names: 'user', 'order'",
+        )
+        output = reporter.report([issue])
+        message = output.split("::error", 1)[1].split("::", 1)[1]
+        assert message.startswith("reserved names: 'user', 'order'")
+
 
 class TestGetReporter:
     """Tests for get_reporter factory function."""
@@ -470,6 +512,30 @@ class TestGitLabReporter:
         data = json.loads(output)
         fingerprints = [e["fingerprint"] for e in data]
         assert len(fingerprints) == len(set(fingerprints))
+
+    def test_fingerprint_distinguishes_same_operation(self):
+        """Two findings on the same operation must not collide.
+
+        They share rule/app/migration/operation but differ in line and
+        message, so GitLab must not deduplicate them.
+        """
+        stream = StringIO()
+        reporter = GitLabReporter(stream=stream)
+        common = dict(
+            rule_id="SM035",
+            severity=Severity.INFO,
+            operation="RunSQL",
+            app_label="myapp",
+            migration_name="0005_two_run_sql",
+            file_path="myapp/migrations/0005_two_run_sql.py",
+        )
+        issues = [
+            Issue(message="first DDL without lock_timeout", line_number=10, **common),
+            Issue(message="second DDL without lock_timeout", line_number=20, **common),
+        ]
+        data = json.loads(reporter.report(issues))
+
+        assert data[0]["fingerprint"] != data[1]["fingerprint"]
 
     def test_location_has_path(self, sample_issues):
         """Test that location contains the file path."""

--- a/tests/unit/test_sarif_reporter.py
+++ b/tests/unit/test_sarif_reporter.py
@@ -635,8 +635,14 @@ class TestSarifAbsolutePathConversion:
 
         assert uri == "myapp/migrations/0001.py"
 
-    def test_srcroot_uri_base_id(self) -> None:
-        """Test that uriBaseId is set to %SRCROOT%."""
+    def test_no_undeclared_uri_base_id(self) -> None:
+        """Test that no (undeclared) uriBaseId is emitted.
+
+        GitHub Code Scanning resolves relative artifact URIs against the
+        repository root; an undeclared uriBaseId (the old ``%SRCROOT%``) is
+        invalid SARIF that GitHub rejects. The URI must also use forward
+        slashes.
+        """
         stream = StringIO()
         reporter = SarifReporter(stream=stream)
 
@@ -654,7 +660,9 @@ class TestSarifAbsolutePathConversion:
         artifact = data["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
             "artifactLocation"
         ]
-        assert artifact["uriBaseId"] == "%SRCROOT%"
+        assert "uriBaseId" not in artifact
+        assert not artifact["uri"].startswith("/")
+        assert "\\" not in artifact["uri"]
 
 
 class TestSarifHelpUri:


### PR DESCRIPTION
## Reporter & CI hardening

Fixes reporter-output correctness issues that break downstream ingestion, plus hardens the PyPI release pipeline. From the audit backlog. 704 tests passing.

### Reporters
- **SARIF** (`reporters/sarif.py`): emit forward-slashed, **repository-root-relative** artifact URIs and **drop the undeclared `%SRCROOT%` `uriBaseId`** — an undeclared uriBaseId is invalid SARIF that GitHub Code Scanning rejects. Paths now resolve against the git root (not the CWD), so they no longer escape the repo with `../..` when the command is run from a subdirectory. (Verified end-to-end: relative, no `uriBaseId`, forward slashes, driver version 0.6.1.)
- **GitHub** (`reporters/github.py`): escape `:` and `,` (in addition to `%`/`\r`/`\n`) in the `file=` and `title=` annotation **properties**, so a Windows drive path or a comma in the operation no longer corrupts the workflow command. The message (data) keeps the correct, looser escaping — `:`/`,` are intentionally left unescaped there.
- **GitLab** (`reporters/gitlab.py`): include the line number and message in the Code Quality **fingerprint** so two distinct findings on the same operation (same rule/app/migration/operation) get distinct fingerprints instead of being silently deduplicated by GitLab.

### Release pipeline (`publish.yml`)
- The PyPI `publish` job now **`needs:` a `test` job** that runs the suite and **verifies the git tag matches `__version__`**, and adds **`twine check`** on the built artifacts before upload. A tag no longer publishes to PyPI on red CI or a tag/version mismatch.

### Tests
- New regression tests for GitHub property escaping (`:`/`,`) and message non-over-escaping, and for GitLab fingerprint distinctness on the same operation; updated the SARIF location test to assert the corrected (no-uriBaseId, relative, forward-slash) output.

> Note: the CI `actions/setup-python@v5` Node-20 deprecation is intentionally left to the existing Dependabot PRs (setup-python@v6, checkout@v6, codeql-action@v4), which are the right vehicle for action-version bumps.
