### PR TITLE
fix: baseline records operation_index to stop over-suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitLab reporter**: include the line number and message in the Code Quality
   fingerprint so two distinct findings on the same operation are no longer
   given identical fingerprints (which made GitLab drop one).
+- **Baseline**: record and match an `operation_index` so baselining one issue
+  in a migration that has several operations of the same type (e.g. multiple
+  `RunSQL` ops) no longer suppresses all of them. Baseline files are now
+  version 2; legacy (version 1) files keep their previous, broader matching.
 
 ### Changed
 

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -265,6 +265,8 @@ class MigrationAnalyzer:
                 issue.app_label = app_label
             if issue.migration_name is None:
                 issue.migration_name = migration_name
+            if issue.operation_index is None:
+                issue.operation_index = operation_index
 
             logger.debug(
                 "Found issue: %s in %s.%s at line %s",

--- a/django_safe_migrations/baseline.py
+++ b/django_safe_migrations/baseline.py
@@ -30,7 +30,9 @@ def generate_baseline(issues: list[Issue], path: str) -> int:
     """Generate a baseline file from current issues.
 
     The baseline records each issue by its rule_id, app_label,
-    migration_name, and operation so it can be matched in future runs.
+    migration_name, operation, and operation_index so it can be matched in
+    future runs. The operation_index distinguishes multiple operations of the
+    same type within one migration (e.g. several ``RunSQL`` operations).
 
     Args:
         issues: Current list of issues.
@@ -47,11 +49,12 @@ def generate_baseline(issues: list[Issue], path: str) -> int:
                 "app_label": issue.app_label,
                 "migration_name": issue.migration_name,
                 "operation": issue.operation,
+                "operation_index": issue.operation_index,
             }
         )
 
     data = {
-        "version": 1,
+        "version": 2,
         "count": len(entries),
         "issues": entries,
     }
@@ -78,7 +81,7 @@ def load_baseline(path: str) -> list[dict[str, Any]]:
     data = json.loads(text)
 
     version = data.get("version", 1)
-    if version != 1:
+    if version not in (1, 2):
         logger.warning(
             "Unknown baseline version %s, attempting to load anyway", version
         )
@@ -94,7 +97,11 @@ def filter_baselined_issues(
 ) -> list[Issue]:
     """Remove issues that are present in the baseline.
 
-    Matching is done by (rule_id, app_label, migration_name, operation).
+    Matching is done by (rule_id, app_label, migration_name, operation,
+    operation_index). For backward compatibility, legacy baseline entries that
+    predate ``operation_index`` (or store it as ``None``) match on the coarser
+    (rule_id, app_label, migration_name, operation) tuple — preserving their
+    original, broader suppression behaviour.
 
     Args:
         issues: Current list of issues.
@@ -103,21 +110,33 @@ def filter_baselined_issues(
     Returns:
         Filtered list of issues not in the baseline.
     """
-    baseline_keys = {
-        (
+    # Precise keys include operation_index; coarse keys are the legacy form
+    # used when an entry has no operation_index recorded.
+    precise_keys = set()
+    coarse_keys = set()
+    for entry in baseline:
+        base = (
             entry.get("rule_id"),
             entry.get("app_label"),
             entry.get("migration_name"),
             entry.get("operation"),
         )
-        for entry in baseline
-    }
+        if entry.get("operation_index") is None:
+            coarse_keys.add(base)
+        else:
+            precise_keys.add(base + (entry.get("operation_index"),))
 
     filtered = []
     suppressed = 0
     for issue in issues:
-        key = (issue.rule_id, issue.app_label, issue.migration_name, issue.operation)
-        if key in baseline_keys:
+        coarse = (
+            issue.rule_id,
+            issue.app_label,
+            issue.migration_name,
+            issue.operation,
+        )
+        precise = coarse + (issue.operation_index,)
+        if precise in precise_keys or coarse in coarse_keys:
             suppressed += 1
         else:
             filtered.append(issue)

--- a/django_safe_migrations/rules/base.py
+++ b/django_safe_migrations/rules/base.py
@@ -34,6 +34,9 @@ class Issue:
         line_number: Line number in the migration file.
         app_label: The Django app label.
         migration_name: The migration name (e.g., '0002_add_field').
+        operation_index: Index of the operation within the migration's
+            ``operations`` list. Disambiguates multiple operations of the
+            same type in one migration (e.g. several ``RunSQL`` ops).
     """
 
     rule_id: str
@@ -45,6 +48,7 @@ class Issue:
     line_number: Optional[int] = None
     app_label: Optional[str] = None
     migration_name: Optional[str] = None
+    operation_index: Optional[int] = None
 
     def __str__(self) -> str:
         """Return a string representation of the issue."""
@@ -72,6 +76,7 @@ class Issue:
             "line_number": self.line_number,
             "app_label": self.app_label,
             "migration_name": self.migration_name,
+            "operation_index": self.operation_index,
         }
 
 

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -504,7 +504,8 @@ Output:
       "file_path": "myapp/migrations/0002_add_email.py",
       "line_number": 15,
       "app_label": "myapp",
-      "migration_name": "0002_add_email"
+      "migration_name": "0002_add_email",
+      "operation_index": 0
     }
   ],
   "summary": {

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -1417,7 +1417,7 @@ class TestBaselineIntegration:
         # Verify the file exists and contains valid JSON
         content = (tmp_path / "baseline.json").read_text(encoding="utf-8")
         data = json.loads(content)
-        assert data["version"] == 1
+        assert data["version"] == 2
         assert data["count"] > 0
         assert len(data["issues"]) > 0
 

--- a/tests/unit/test_baseline.py
+++ b/tests/unit/test_baseline.py
@@ -68,13 +68,13 @@ class TestGenerateBaseline:
         assert "count" in data
         assert "issues" in data
 
-    def test_baseline_version_is_one(self, tmp_path, sample_issues):
-        """Test that the baseline version is 1."""
+    def test_baseline_version_is_two(self, tmp_path, sample_issues):
+        """Test that the baseline format version is 2 (adds operation_index)."""
         baseline_path = str(tmp_path / "baseline.json")
         generate_baseline(sample_issues, baseline_path)
 
         data = json.loads((tmp_path / "baseline.json").read_text(encoding="utf-8"))
-        assert data["version"] == 1
+        assert data["version"] == 2
 
     def test_baseline_count_matches(self, tmp_path, sample_issues):
         """Test that count in baseline matches the number of issues."""
@@ -262,6 +262,65 @@ class TestFilterBaselinedIssues:
             }
         ]
         filtered = filter_baselined_issues([], baseline)
+        assert filtered == []
+
+    @staticmethod
+    def _two_run_sql_issues():
+        """Two issues sharing rule/app/migration/operation but distinct index."""
+        common = dict(
+            rule_id="SM007",
+            severity=Severity.WARNING,
+            operation="RunSQL",
+            app_label="myapp",
+            migration_name="0005_two_run_sql",
+        )
+        return [
+            Issue(message="first", operation_index=0, **common),
+            Issue(message="second", operation_index=1, **common),
+        ]
+
+    def test_precise_index_suppresses_only_matching_operation(self):
+        """A v2 baseline (with operation_index) suppresses only that op."""
+        issues = self._two_run_sql_issues()
+        baseline = [
+            {
+                "rule_id": "SM007",
+                "app_label": "myapp",
+                "migration_name": "0005_two_run_sql",
+                "operation": "RunSQL",
+                "operation_index": 0,
+            }
+        ]
+
+        filtered = filter_baselined_issues(issues, baseline)
+
+        # Only the index-0 RunSQL is suppressed; the second one survives.
+        assert [i.operation_index for i in filtered] == [1]
+
+    def test_legacy_entry_without_index_suppresses_all_same_operation(self):
+        """A legacy (v1) entry with no operation_index keeps broad behaviour."""
+        issues = self._two_run_sql_issues()
+        baseline = [
+            {
+                "rule_id": "SM007",
+                "app_label": "myapp",
+                "migration_name": "0005_two_run_sql",
+                "operation": "RunSQL",
+            }
+        ]
+
+        filtered = filter_baselined_issues(issues, baseline)
+
+        assert filtered == []
+
+    def test_generated_baseline_roundtrip_suppresses_both(self, tmp_path):
+        """Generating a baseline from both ops and re-filtering suppresses both."""
+        issues = self._two_run_sql_issues()
+        path = str(tmp_path / "baseline.json")
+        generate_baseline(issues, path)
+
+        filtered = filter_baselined_issues(issues, load_baseline(path))
+
         assert filtered == []
 
     def test_filters_multiple_matching(self, sample_issues):


### PR DESCRIPTION
## Baseline: record `operation_index` to stop over-suppression

The baseline matched issues on `(rule_id, app_label, migration_name, operation)` only. When a migration has **several operations of the same type** (e.g. multiple `RunSQL` ops), they all share one key — so baselining one issue silently suppressed all of them, and distinct findings couldn't be told apart.

### Fix
- Add `operation_index` to the `Issue` dataclass (and `to_dict`); the analyzer populates it from each operation's position in the migration's `operations` list.
- `generate_baseline` records `operation_index` and bumps the baseline format to **version 2**.
- `filter_baselined_issues` matches on `operation_index` when present. **Backward compatible:** legacy version-1 entries (no `operation_index`) keep their previous, broader coarse-key matching, so existing baseline files keep working.

### Tests
- `test_precise_index_suppresses_only_matching_operation` — a v2 entry for index 0 suppresses only that op, not the index-1 op on the same migration.
- `test_legacy_entry_without_index_suppresses_all_same_operation` — a v1-style entry still suppresses all matching ops (preserved behaviour).
- `test_generated_baseline_roundtrip_suppresses_both` — generate → load → filter suppresses exactly the recorded ops.
- Updated the version assertions (1 → 2) and the JSON example in `docs/ci_integration.md`.

707 tests passing; pre-commit green.
