### PR TITLE
fix: SM035 ordering, SM036 multi-statement, SM026 test, CI Node-20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in a migration that has several operations of the same type (e.g. multiple
   `RunSQL` ops) no longer suppresses all of them. Baseline files are now
   version 2; legacy (version 1) files keep their previous, broader matching.
+- **SM035**: only treat a `SET lock_timeout` as protection when it runs
+  *before* the DDL (earlier in the SQL list, or in an earlier operation). A
+  lock_timeout set after the DDL no longer silences the rule (false negative).
+- **SM036**: evaluate each SQL statement independently, so a bare
+  `CREATE`/`DROP TABLE` is flagged even when a sibling statement in the same
+  `RunSQL` already uses `IF [NOT] EXISTS` (previously a sibling masked it).
 
 ### Changed
 
@@ -45,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verifies the git tag matches `__version__` before publishing, and runs
   `twine check` on the built artifacts. A tag no longer publishes to PyPI when
   tests fail or the version is mismatched.
+- **CI**: bump `actions/setup-python` from v5 to v6 (runs on Node 24,
+  resolving the Node 20 runtime deprecation).
 
 ## [0.6.1] - 2026-06-03
 

--- a/django_safe_migrations/rules/run_sql.py
+++ b/django_safe_migrations/rules/run_sql.py
@@ -14,6 +14,32 @@ if TYPE_CHECKING:
     from django.db.migrations.operations.base import Operation
 
 
+def _split_sql_statements(sql: object) -> list[str]:
+    """Return the individual SQL statements of a ``RunSQL.sql`` value, in order.
+
+    ``RunSQL.sql`` may be a single string, a list/tuple of strings, or a list
+    of ``(sql, params)`` tuples. Multi-statement strings are split on ``;``.
+    Element/statement order is preserved so callers can reason about ordering.
+    """
+    raw_chunks: list[str] = []
+    if isinstance(sql, (list, tuple)):
+        for element in sql:
+            if isinstance(element, (list, tuple)) and element:
+                raw_chunks.append(str(element[0]))
+            else:
+                raw_chunks.append(str(element))
+    else:
+        raw_chunks.append(str(sql))
+
+    statements: list[str] = []
+    for chunk in raw_chunks:
+        for stmt in chunk.split(";"):
+            stmt = stmt.strip()
+            if stmt:
+                statements.append(stmt)
+    return statements
+
+
 class RunSQLWithoutReverseRule(BaseRule):
     """Detect RunSQL without reverse_sql defined.
 
@@ -681,40 +707,43 @@ class RequireLockTimeoutRule(BaseRule):
         if not isinstance(operation, migrations.RunSQL):
             return None
 
-        sql = getattr(operation, "sql", "")
-        if isinstance(sql, (list, tuple)):
-            sql_str = " ".join(str(s) for s in sql)
-        else:
-            sql_str = str(sql)
-
-        sql_upper = sql_str.upper()
-
-        # Check if SQL contains DDL patterns
-        has_ddl = any(re.search(p, sql_upper) for p in self.DDL_PATTERNS)
-        if not has_ddl:
-            return None
-
-        # Check if lock_timeout is set in this SQL or in the same migration
-        if "LOCK_TIMEOUT" in sql_upper:
-            return None
-
-        # Check other operations in the migration for lock_timeout
-        all_operations = getattr(migration, "operations", [])
-        for op in all_operations:
+        # A lock_timeout only protects a DDL statement if it is set BEFORE it.
+        # Consider earlier operations in the migration: a prior RunSQL that sets
+        # lock_timeout protects DDL in this operation; later ops do not.
+        seen_lock_timeout = False
+        for op in getattr(migration, "operations", []):
+            if op is operation:
+                break  # stop at the current op — later ops can't protect it
             if isinstance(op, migrations.RunSQL):
-                op_sql = getattr(op, "sql", "")
-                if isinstance(op_sql, (list, tuple)):
-                    op_sql = " ".join(str(s) for s in op_sql)
-                if "LOCK_TIMEOUT" in str(op_sql).upper():
-                    return None
+                op_text = " ".join(_split_sql_statements(getattr(op, "sql", "")))
+                if "LOCK_TIMEOUT" in op_text.upper():
+                    seen_lock_timeout = True
+                    break
+
+        # Then scan this operation's statements in order: a DDL statement that
+        # has no preceding lock_timeout (here or in an earlier op) is unprotected.
+        has_unprotected_ddl = False
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            stmt_upper = statement.upper()
+            if "LOCK_TIMEOUT" in stmt_upper:
+                seen_lock_timeout = True
+                continue
+            if any(re.search(p, stmt_upper) for p in self.DDL_PATTERNS):
+                if not seen_lock_timeout:
+                    has_unprotected_ddl = True
+                    break
+
+        if not has_unprotected_ddl:
+            return None
 
         return self.create_issue(
             operation=operation,
             migration=migration,
             message=(
-                "RunSQL contains DDL statement without SET lock_timeout. "
-                "Consider setting a lock_timeout to prevent indefinite "
-                "blocking while waiting for locks."
+                "RunSQL contains a DDL statement without a preceding SET "
+                "lock_timeout. Set lock_timeout before the DDL (earlier in "
+                "the SQL list or in an earlier operation) to prevent "
+                "indefinite blocking while waiting for locks."
             ),
         )
 
@@ -786,17 +815,17 @@ class PreferIfExistsRule(BaseRule):
         if not isinstance(operation, migrations.RunSQL):
             return None
 
-        sql = getattr(operation, "sql", "")
-        if isinstance(sql, (list, tuple)):
-            sql_str = " ".join(str(s) for s in sql)
-        else:
-            sql_str = str(sql)
+        # Evaluate each statement independently so a bare CREATE/DROP TABLE is
+        # still flagged when a sibling statement uses IF [NOT] EXISTS. RunSQL.sql
+        # may be a string, a list of strings, or a list of (sql, params) tuples;
+        # multi-statement strings are split on ';'.
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            stmt_upper = statement.upper()
 
-        sql_upper = sql_str.upper()
-
-        # Check CREATE TABLE without IF NOT EXISTS
-        if re.search(r"CREATE\s+TABLE\b", sql_upper):
-            if not re.search(r"CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b", sql_upper):
+            # CREATE TABLE without IF NOT EXISTS
+            if re.search(r"CREATE\s+TABLE\b", stmt_upper) and not re.search(
+                r"CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b", stmt_upper
+            ):
                 return self.create_issue(
                     operation=operation,
                     migration=migration,
@@ -807,9 +836,10 @@ class PreferIfExistsRule(BaseRule):
                     ),
                 )
 
-        # Check DROP TABLE without IF EXISTS
-        if re.search(r"DROP\s+TABLE\b", sql_upper):
-            if not re.search(r"DROP\s+TABLE\s+IF\s+EXISTS\b", sql_upper):
+            # DROP TABLE without IF EXISTS
+            if re.search(r"DROP\s+TABLE\b", stmt_upper) and not re.search(
+                r"DROP\s+TABLE\s+IF\s+EXISTS\b", stmt_upper
+            ):
                 return self.create_issue(
                     operation=operation,
                     migration=migration,

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1655,7 +1655,7 @@ ______________________________________________________________________
 
 ### What it detects
 
-`RunSQL` operations containing DDL statements (`ALTER TABLE`, `CREATE INDEX`, `DROP INDEX`, etc.) without a `SET lock_timeout` statement in the same migration.
+`RunSQL` operations containing DDL statements (`ALTER TABLE`, `CREATE INDEX`, `DROP INDEX`, etc.) with no `SET lock_timeout` statement running **before** the DDL — either earlier in the same SQL list or in an earlier operation. A `SET lock_timeout` that runs after the DDL gives it no protection and does not silence the rule.
 
 ### Why it's relevant
 

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -804,25 +804,26 @@ class TestNewRulesV040:
     def test_detects_sm026_run_python_no_batching(self):
         """Test SM026 detection for RunPython without batching.
 
-        Migration 0020_run_python_no_batching.py uses .all() without .iterator().
+        Migration 0020_run_python_no_batching.py uses .all() without .iterator()
+        or any batching, so SM026 must flag it exactly once.
         """
         out = StringIO()
         with pytest.raises(SystemExit):
             call_command("check_migrations", "testapp", format="json", stdout=out)
 
-        output = out.getvalue()
-        data = json.loads(output)
+        data = json.loads(out.getvalue())
 
-        # Find SM026 issues
         sm026_issues = [i for i in data["issues"] if i.get("rule_id") == "SM026"]
-        # Note: SM026 may not trigger if source inspection fails
-        # This is acceptable behavior documented in the rule
-        if len(sm026_issues) > 0:
-            # Verify it's from the right migration
-            migration_names = [i.get("migration_name", "") for i in sm026_issues]
-            assert any(
-                "0020_run_python_no_batching" in name for name in migration_names
-            ), "SM026 should be detected in 0020_run_python_no_batching"
+        assert len(sm026_issues) == 1, "SM026 should fire exactly once on testapp"
+
+        issue = sm026_issues[0]
+        assert "0020_run_python_no_batching" in issue.get("migration_name", "")
+        assert issue["severity"] == "warning"
+        # Robust message substrings the rule always emits
+        message = issue["message"].lower()
+        assert "update_all_users" in issue["message"]
+        assert ".all()" in message
+        assert "iterator" in message or "batch" in message
 
 
 class TestCategoryConfiguration:

--- a/tests/test_project/testapp/migrations/0020_run_python_no_batching.py
+++ b/tests/test_project/testapp/migrations/0020_run_python_no_batching.py
@@ -8,9 +8,9 @@ from django.db import migrations
 
 
 def update_all_users(apps, schema_editor):
-    """Update all users without batching - dangerous for large tables."""
+    """Update every user one by one (intentionally memory-heavy fixture)."""
     User = apps.get_model("testapp", "User")
-    # This should trigger SM026 - .all() without .iterator()
+    # Loads the entire table at once on purpose for the SM026 test
     for user in User.objects.all():
         user.order = 0
         user.save()

--- a/tests/unit/rules/test_run_sql_rules.py
+++ b/tests/unit/rules/test_run_sql_rules.py
@@ -710,6 +710,79 @@ class TestRequireLockTimeoutRule:
         assert suggestion is not None
         assert "lock_timeout" in suggestion.lower()
 
+    def test_flags_lock_timeout_after_ddl_in_list(self, mock_migration):
+        """SM035 flags DDL when SET lock_timeout comes AFTER it in the list."""
+        from django_safe_migrations.rules.run_sql import RequireLockTimeoutRule
+
+        rule = RequireLockTimeoutRule()
+        operation = migrations.RunSQL(
+            sql=[
+                "ALTER TABLE users ADD COLUMN age INTEGER",
+                "SET lock_timeout = '5s'",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM035"
+
+    def test_allows_lock_timeout_before_ddl_in_list(self, mock_migration):
+        """SM035 stays silent when SET lock_timeout precedes the DDL."""
+        from django_safe_migrations.rules.run_sql import RequireLockTimeoutRule
+
+        rule = RequireLockTimeoutRule()
+        operation = migrations.RunSQL(
+            sql=[
+                "SET lock_timeout = '5s'",
+                "ALTER TABLE users ADD COLUMN age INTEGER",
+                "SET lock_timeout = '0'",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        )
+
+        assert rule.check(operation, mock_migration) is None
+
+    def test_flags_ddl_when_lock_timeout_is_later_operation(
+        self, mock_migration_factory
+    ):
+        """SM035 flags a DDL op when lock_timeout is set in a LATER op."""
+        from django_safe_migrations.rules.run_sql import RequireLockTimeoutRule
+
+        ddl_op = migrations.RunSQL(
+            sql="ALTER TABLE users ADD COLUMN age INTEGER",
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        lock_op = migrations.RunSQL(
+            sql="SET lock_timeout = '5s'", reverse_sql=migrations.RunSQL.noop
+        )
+        migration = mock_migration_factory([ddl_op, lock_op])
+
+        rule = RequireLockTimeoutRule()
+        issue = rule.check(ddl_op, migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM035"
+
+    def test_allows_ddl_when_lock_timeout_is_earlier_operation(
+        self, mock_migration_factory
+    ):
+        """SM035 stays silent when an EARLIER op already set lock_timeout."""
+        from django_safe_migrations.rules.run_sql import RequireLockTimeoutRule
+
+        lock_op = migrations.RunSQL(
+            sql="SET lock_timeout = '5s'", reverse_sql=migrations.RunSQL.noop
+        )
+        ddl_op = migrations.RunSQL(
+            sql="ALTER TABLE users ADD COLUMN age INTEGER",
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        migration = mock_migration_factory([lock_op, ddl_op])
+
+        rule = RequireLockTimeoutRule()
+
+        assert rule.check(ddl_op, migration) is None
+
 
 class TestPreferIfExistsRule:
     """Tests for PreferIfExistsRule (SM036)."""
@@ -864,3 +937,82 @@ class TestPreferIfExistsRule:
         assert suggestion is not None
         assert "IF NOT EXISTS" in suggestion
         assert "IF EXISTS" in suggestion
+
+    def test_detects_bare_create_among_safe_siblings_list(self, mock_migration):
+        """A bare CREATE TABLE is flagged even if a sibling uses IF NOT EXISTS."""
+        from django_safe_migrations.rules.run_sql import PreferIfExistsRule
+
+        rule = PreferIfExistsRule()
+        operation = migrations.RunSQL(
+            sql=[
+                "CREATE TABLE IF NOT EXISTS a (id INTEGER)",
+                "CREATE TABLE b (id INTEGER)",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM036"
+        assert "CREATE TABLE" in issue.message
+
+    def test_detects_bare_create_in_multistatement_string(self, mock_migration):
+        """A bare CREATE TABLE in a ';'-separated string is flagged."""
+        from django_safe_migrations.rules.run_sql import PreferIfExistsRule
+
+        rule = PreferIfExistsRule()
+        operation = migrations.RunSQL(
+            sql=(
+                "CREATE TABLE IF NOT EXISTS a (id INTEGER); "
+                "CREATE TABLE b (id INTEGER);"
+            ),
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM036"
+
+    def test_detects_bare_drop_among_safe_siblings(self, mock_migration):
+        """A bare DROP TABLE is flagged even if a sibling uses IF EXISTS."""
+        from django_safe_migrations.rules.run_sql import PreferIfExistsRule
+
+        rule = PreferIfExistsRule()
+        operation = migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS a; DROP TABLE b;",
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM036"
+        assert "DROP TABLE" in issue.message
+
+    def test_allows_all_safe_multistatement(self, mock_migration):
+        """No false positive when every statement is defensive."""
+        from django_safe_migrations.rules.run_sql import PreferIfExistsRule
+
+        rule = PreferIfExistsRule()
+        operation = migrations.RunSQL(
+            sql=[
+                "CREATE TABLE IF NOT EXISTS a (id INTEGER)",
+                "DROP TABLE IF EXISTS b",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        )
+
+        assert rule.check(operation, mock_migration) is None
+
+    def test_handles_sql_list_with_params_tuples(self, mock_migration):
+        """A bare CREATE TABLE in (sql, params) tuple-list form is flagged."""
+        from django_safe_migrations.rules.run_sql import PreferIfExistsRule
+
+        rule = PreferIfExistsRule()
+        operation = migrations.RunSQL(
+            sql=[("CREATE TABLE a (id INTEGER)", None)],
+            reverse_sql=migrations.RunSQL.noop,
+        )
+        issue = rule.check(operation, mock_migration)
+
+        assert issue is not None
+        assert issue.rule_id == "SM036"


### PR DESCRIPTION
## Backlog: SM035 / SM036 accuracy, SM026 test, CI Node-20

Each candidate was verified against the current code by a read-only investigation pass before implementing; two further candidates were **deliberately not changed** (see bottom). 716 tests passing.

### Rule accuracy
- **SM035** (`require_lock_timeout`): a `SET lock_timeout` now only counts as protection when it runs **before** the DDL — earlier in the SQL list, or in an earlier operation. A lock_timeout set *after* the DDL gives no protection and no longer silences the rule (was a false negative). Ordering is evaluated within the op's statement list and across earlier operations.
- **SM036** (`prefer_if_exists`): each SQL statement is now evaluated **independently** (list elements split, `;`-separated strings split, `(sql, params)` tuples unwrapped), so a bare `CREATE`/`DROP TABLE` is flagged even when a sibling statement in the same `RunSQL` already uses `IF [NOT] EXISTS` (previously one safe sibling masked all bare ones). Adds a shared `_split_sql_statements` helper.

### Test quality
- **SM026** fixture + test: the fixture function's docstring/comment contained `"batch"` and `".iterator("`, which fooled SM026's `inspect.getsource` heuristic so the rule **never fired** — and the integration test wrapped its only assertion in `if len(...) > 0`, passing vacuously. Cleaned the fixture body; the test now asserts SM026 fires exactly once with the expected migration/severity/message. (testapp issue count goes 28 → 29; no test asserts a global total.)

### CI
- Bump `actions/setup-python` v5 → v6 (Node 24), clearing the Node-20 runtime deprecation. All other actions were already current and there were no open Dependabot PRs left to merge.

### Investigated and intentionally NOT changed
- **SM009/SM017 `Meta.constraints` in `CreateModel`**: a constraint added at table-creation validates against zero rows — flagging it would be a **false positive**. Left as-is.
- **DDL keywords inside SQL string literals/comments**: correctly handling this needs real tokenization (dollar-quoting, escaped quotes, nested comments); a naive stripper would create new false negatives. Not worth the churn for INFO-level rules.

9 new SM035/SM036 regression tests; docs + CHANGELOG updated.
