### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-04
+
 ### Fixed
 
 - **SM004**: stop flagging a `CharField` `max_length` *increase* as a table

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.6.1"
+version = "0.6.2"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release v0.6.2

Bumps the version to **0.6.2** (`pyproject.toml` + `__init__.py`, kept in sync — guarded by the version-consistency test) and dates the `[0.6.2]` changelog section (2026-06-04).

Merging this and tagging `v0.6.2` publishes to PyPI via the now-hardened pipeline (runs the suite, checks the tag matches `__version__`, runs `twine check`, then publishes).

### What ships in v0.6.2 (four batches of audit fixes since v0.6.1)
- **Rule accuracy** — SM004 (max_length increase FP + db_collation/db_index FN), SM012 (schema-qualified/quoted enums), SM022 (`date.today`), SM024 (broken `params=` suggestion), SM028 (Integer/SmallInteger PKs), SM017 added to the `postgresql` category, SM035 (lock_timeout must precede DDL), SM036 (per-statement `IF [NOT] EXISTS`).
- **Reporter hardening** — SARIF repo-root-relative URIs + dropped invalid `%SRCROOT%`; GitHub annotation property escaping (`:`/`,`); GitLab fingerprint collisions.
- **Baseline** — `operation_index` so baselining one of several same-type ops no longer suppresses all (format v2, backward-compatible).
- **Release/CI hardening** — test-gated + tag/version-checked + `twine check`ed publish pipeline; `actions/setup-python` v5 → v6 (Node 24).

716 tests passing; pre-commit clean.
