### PR TITLE
fix: --diff CommandError when AppConfig.label differs from directory name (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `--diff` misidentifying app labels when `AppConfig.label` differs from
+  the package directory name. The app label is now resolved via Django's app
+  registry (`AppConfig.path`) instead of assuming directory name equals label.
+
 ## [0.6.2] - 2026-06-04
 
 ### Fixed

--- a/django_safe_migrations/diff.py
+++ b/django_safe_migrations/diff.py
@@ -102,6 +102,16 @@ def get_changed_apps_and_migrations(
     files = get_changed_migration_files(base_ref)
     result: list[tuple[str, str]] = []
 
+    # Map resolved app package paths to their registered labels once. Using the
+    # registry label (rather than assuming directory name == label) handles
+    # custom ``AppConfig.label`` values; resolving paths makes the lookup robust
+    # to symlinks / non-normalized roots, and building the dict once keeps this
+    # O(files) instead of O(files x app_configs).
+    path_to_label = {
+        Path(app_config.path).resolve(): app_config.label
+        for app_config in django_apps.get_app_configs()
+    }
+
     for filepath in files:
         path = Path(filepath)
         # Expected: .../app_name/migrations/0001_initial.py
@@ -112,13 +122,7 @@ def get_changed_apps_and_migrations(
         migrations_dir = path.parent  # .../app_name/migrations/
         app_dir = migrations_dir.parent  # .../app_name/
 
-        # Prefer the app registry label in case AppConfig.label differs from
-        # the package directory name (e.g. namespaced apps or custom labels).
-        app_label = app_dir.name
-        for app_config in django_apps.get_app_configs():
-            if Path(app_config.path) == app_dir:
-                app_label = app_config.label
-                break
+        app_label = path_to_label.get(app_dir.resolve(), app_dir.name)
 
         result.append((app_label, migration_name))
 

--- a/django_safe_migrations/diff.py
+++ b/django_safe_migrations/diff.py
@@ -16,6 +16,8 @@ import os
 import subprocess  # nosec B404
 from pathlib import Path
 
+from django.apps import apps as django_apps
+
 logger = logging.getLogger("django_safe_migrations")
 
 
@@ -87,6 +89,9 @@ def get_changed_apps_and_migrations(
     """Get (app_label, migration_name) pairs for changed migrations.
 
     Parses the file paths to extract app labels and migration names.
+    The app label is resolved via Django's app registry so that apps
+    whose ``AppConfig.label`` differs from their package directory name
+    are handled correctly.
 
     Args:
         base_ref: Git ref to diff against.
@@ -107,8 +112,13 @@ def get_changed_apps_and_migrations(
         migrations_dir = path.parent  # .../app_name/migrations/
         app_dir = migrations_dir.parent  # .../app_name/
 
-        # The app label is typically the directory name
+        # Prefer the app registry label in case AppConfig.label differs from
+        # the package directory name (e.g. namespaced apps or custom labels).
         app_label = app_dir.name
+        for app_config in django_apps.get_app_configs():
+            if Path(app_config.path) == app_dir:
+                app_label = app_config.label
+                break
 
         result.append((app_label, migration_name))
 

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -302,6 +302,50 @@ class TestGetChangedAppsAndMigrations:
 
         mock_fn.assert_called_once_with("feature-branch")
 
+    def test_resolves_custom_app_label(self, tmp_path):
+        """Test that a custom AppConfig.label is used instead of the directory name."""
+        app_dir = tmp_path / "billing_app"
+        migrations_dir = app_dir / "migrations"
+        migrations_dir.mkdir(parents=True)
+
+        changed_files = [str(migrations_dir / "0001_initial.py")]
+
+        mock_app_config = MagicMock()
+        mock_app_config.path = str(app_dir)
+        mock_app_config.label = "billing"  # label differs from dir name "billing_app"
+
+        with (
+            patch(
+                "django_safe_migrations.diff.get_changed_migration_files",
+                return_value=changed_files,
+            ),
+            patch(
+                "django_safe_migrations.diff.django_apps.get_app_configs",
+                return_value=[mock_app_config],
+            ),
+        ):
+            result = get_changed_apps_and_migrations("main")
+
+        assert result == [("billing", "0001_initial")]
+
+    def test_falls_back_to_dir_name_when_app_not_registered(self):
+        """Test that the directory name is used when no app registry match exists."""
+        changed_files = ["/project/unregistered_app/migrations/0001_initial.py"]
+
+        with (
+            patch(
+                "django_safe_migrations.diff.get_changed_migration_files",
+                return_value=changed_files,
+            ),
+            patch(
+                "django_safe_migrations.diff.django_apps.get_app_configs",
+                return_value=[],
+            ),
+        ):
+            result = get_changed_apps_and_migrations("main")
+
+        assert result == [("unregistered_app", "0001_initial")]
+
     def test_multiple_migrations_same_app(self):
         """Test handling multiple migrations from the same app."""
         changed_files = [


### PR DESCRIPTION
## Fix `--diff` `CommandError` when `AppConfig.label` differs from the directory name

This lands the fix from **#45 by @Sticky-Bits** (rebased onto current `main` to resolve the CHANGELOG conflict), plus a small hardening follow-up.

### The fix (credit: @Sticky-Bits, #45)
`--diff` derived the app label from the migration file's parent-directory name, but `MigrationLoader.disk_migrations` is keyed by `AppConfig.label`. When an app sets a custom `label` (or is a namespaced package), the lookup missed and the command raised `CommandError: Migration '…' not found for app '…'`. The label is now resolved via Django's app registry (`AppConfig.path` → `AppConfig.label`), falling back to the directory name for unregistered apps. Includes unit tests + CHANGELOG.

### Hardening follow-up
- Compare **resolved** paths (`Path(...).resolve()`) so the lookup survives symlinks / non-normalized git roots.
- Build the path→label map **once** before the loop — `O(files)` instead of `O(files × app_configs)`.

Composes with the v0.6.1 `--diff` robustness change (a changed file that still doesn't resolve to a known migration is skipped with a warning rather than aborting the run).

Closes #45. 718 tests passing; pre-commit clean.
