### PR TITLE
fix: surface real Django setup errors in the standalone CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `--diff` misidentifying app labels when `AppConfig.label` differs from
   the package directory name. The app label is now resolved via Django's app
   registry (`AppConfig.path`) instead of assuming directory name equals label.
+- Standalone CLI: when `DJANGO_SETTINGS_MODULE` is set but `django.setup()`
+  fails (e.g. an import error in settings or an installed app), report the
+  actual error instead of swallowing it and printing a misleading "please set
+  `DJANGO_SETTINGS_MODULE`" message.
 
 ## [0.6.2] - 2026-06-04
 

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -42,12 +42,20 @@ def setup_django() -> bool:
             del os.environ["DJANGO_SETTINGS_MODULE"]
         return False
 
+    # DJANGO_SETTINGS_MODULE is explicitly set: surface the real error instead
+    # of failing silently with a misleading "please set DJANGO_SETTINGS_MODULE".
     try:
         import django
 
         django.setup()
         return True
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"Error: failed to configure Django with "
+            f"DJANGO_SETTINGS_MODULE='{settings_module}': "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
         return False
 
 
@@ -220,13 +228,16 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     if args.list_rules:
         return list_rules(args.format)
 
-    # Setup Django
+    # Setup Django. When DJANGO_SETTINGS_MODULE was explicitly set,
+    # setup_django() already reported the underlying error; only show the
+    # "please set it" hint when it is genuinely not set.
     if not setup_django():
-        print(
-            "Error: Could not configure Django. "
-            "Please set DJANGO_SETTINGS_MODULE environment variable.",
-            file=sys.stderr,
-        )
+        if not os.environ.get("DJANGO_SETTINGS_MODULE"):
+            print(
+                "Error: Could not configure Django. "
+                "Please set the DJANGO_SETTINGS_MODULE environment variable.",
+                file=sys.stderr,
+            )
         return 1
 
     # Import after Django setup

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -34,8 +34,11 @@ class TestSetupDjango:
         assert "boom" in err
 
     def test_cleans_up_env_when_module_not_set(self, monkeypatch):
-        """When no module is set and no candidate works, the probe env var is
-        cleaned up and setup_django returns False."""
+        """The probe env var is cleaned up when no module works.
+
+        When no module is set and no candidate succeeds, ``setup_django``
+        returns False and removes the temporary ``DJANGO_SETTINGS_MODULE``.
+        """
         monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
         import django
 
@@ -66,8 +69,11 @@ class TestMain:
         assert any(rule["rule_id"] == "SM001" for rule in data)
 
     def test_no_misleading_hint_when_module_is_set(self, monkeypatch, capsys):
-        """When DJANGO_SETTINGS_MODULE is set but setup fails, main() exits 1
-        without printing the 'please set DJANGO_SETTINGS_MODULE' hint."""
+        """No misleading hint is shown when the module is set.
+
+        When ``DJANGO_SETTINGS_MODULE`` is set but setup fails, ``main()``
+        exits 1 without printing the "please set it" hint.
+        """
         monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "broken.settings")
         monkeypatch.setattr(cli, "setup_django", lambda: False)
 
@@ -78,8 +84,11 @@ class TestMain:
         assert "Please set" not in err
 
     def test_hint_shown_when_module_not_set(self, monkeypatch, capsys):
-        """When DJANGO_SETTINGS_MODULE is not set and setup fails, main() shows
-        the helpful hint."""
+        """The hint is shown when the module is not set.
+
+        When ``DJANGO_SETTINGS_MODULE`` is unset and setup fails, ``main()``
+        prints the helpful hint.
+        """
         monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
         monkeypatch.setattr(cli, "setup_django", lambda: False)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,90 @@
+"""Tests for the standalone CLI (django_safe_migrations.cli)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from django_safe_migrations import cli
+
+
+def _raise(*args, **kwargs):
+    raise ImportError("boom: cannot import settings")
+
+
+class TestSetupDjango:
+    """Tests for setup_django() error handling."""
+
+    def test_surfaces_real_error_when_module_set(self, monkeypatch, capsys):
+        """An explicit DJANGO_SETTINGS_MODULE that fails reports the real error.
+
+        Previously the exception was swallowed and the CLI printed a misleading
+        "please set DJANGO_SETTINGS_MODULE" even though it was set.
+        """
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "broken.settings")
+        import django
+
+        monkeypatch.setattr(django, "setup", _raise)
+
+        assert cli.setup_django() is False
+
+        err = capsys.readouterr().err
+        assert "broken.settings" in err
+        assert "ImportError" in err
+        assert "boom" in err
+
+    def test_cleans_up_env_when_module_not_set(self, monkeypatch):
+        """When no module is set and no candidate works, the probe env var is
+        cleaned up and setup_django returns False."""
+        monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
+        import django
+
+        monkeypatch.setattr(django, "setup", _raise)
+
+        assert cli.setup_django() is False
+        assert "DJANGO_SETTINGS_MODULE" not in os.environ
+
+
+class TestMain:
+    """Tests for the main() entry point."""
+
+    def test_list_rules_returns_zero(self, capsys):
+        """--list-rules works without Django setup and lists rule IDs."""
+        rc = cli.main(["--list-rules"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "SM001" in out
+
+    def test_list_rules_json_is_valid(self, capsys):
+        """--list-rules --format=json emits parseable JSON of all rules."""
+        rc = cli.main(["--list-rules", "--format=json"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        data = json.loads(out)
+        assert any(rule["rule_id"] == "SM001" for rule in data)
+
+    def test_no_misleading_hint_when_module_is_set(self, monkeypatch, capsys):
+        """When DJANGO_SETTINGS_MODULE is set but setup fails, main() exits 1
+        without printing the 'please set DJANGO_SETTINGS_MODULE' hint."""
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "broken.settings")
+        monkeypatch.setattr(cli, "setup_django", lambda: False)
+
+        rc = cli.main(["myapp"])
+        err = capsys.readouterr().err
+
+        assert rc == 1
+        assert "Please set" not in err
+
+    def test_hint_shown_when_module_not_set(self, monkeypatch, capsys):
+        """When DJANGO_SETTINGS_MODULE is not set and setup fails, main() shows
+        the helpful hint."""
+        monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
+        monkeypatch.setattr(cli, "setup_django", lambda: False)
+
+        rc = cli.main(["myapp"])
+        err = capsys.readouterr().err
+
+        assert rc == 1
+        assert "DJANGO_SETTINGS_MODULE" in err


### PR DESCRIPTION
## Surface real Django setup errors in the standalone CLI

The standalone CLI (`check-migrations` / `cli.main`) swallowed the real error when `DJANGO_SETTINGS_MODULE` **was** set but `django.setup()` failed (a typo in settings, an `ImportError` in an installed app, `ImproperlyConfigured`, …), then printed a misleading **"Please set DJANGO_SETTINGS_MODULE"** — even though it was already set. That sent users debugging the wrong thing.

### Fix
- `setup_django()` now reports the actual exception (type + message + the module name) when an explicitly-set `DJANGO_SETTINGS_MODULE` fails.
- `main()` only prints the "please set it" hint when the variable is genuinely **unset** (the auto-discovery path), so it's no longer shown over a real settings error.

### Tests
Adds `tests/unit/test_cli.py` — the standalone CLI previously had **no direct test coverage**:
- `setup_django` surfaces the real error when the module is set; cleans up the probe env var when it isn't
- `--list-rules` (console + JSON) returns 0 and lists rules without needing Django setup
- `main()` shows the real error path vs. the hint path correctly

724 tests passing; pre-commit clean. (Lands in a future v0.6.3 alongside the `--diff` app-label fix already on `main`.)
