### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-04
+
 ### Fixed
 
 - Fix `--diff` misidentifying app labels when `AppConfig.label` differs from
   the package directory name. The app label is now resolved via Django's app
   registry (`AppConfig.path`) instead of assuming directory name equals label.
+  (Thanks @Sticky-Bits.)
 - Standalone CLI: when `DJANGO_SETTINGS_MODULE` is set but `django.setup()`
   fails (e.g. an import error in settings or an installed app), report the
   actual error instead of swallowing it and printing a misleading "please set

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.6.2"
+version = "0.6.3"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release **v0.6.3** — two bug fixes since v0.6.2:

- **`--diff`**: fix `CommandError` when an app's `AppConfig.label` differs from its package directory name (resolved via the app registry, with symlink-safe path matching). Thanks @Sticky-Bits (#53).
- **Standalone CLI**: surface the real `django.setup()` error when `DJANGO_SETTINGS_MODULE` is set but fails, instead of a misleading "please set DJANGO_SETTINGS_MODULE" (#54).

Bumps version to 0.6.3 (both `pyproject.toml` + `__init__.py`, guarded by the version-consistency test) and dates the changelog. Merging + tagging `v0.6.3` publishes to PyPI via the gated pipeline. 724 tests passing.