### PR TITLE
docs: refined v0.7.0 implementation plan

### DIFF
--- a/docs/roadmap/v0.7.0.md
+++ b/docs/roadmap/v0.7.0.md
@@ -1,0 +1,145 @@
+# v0.7.0 Plan — Django 5.x/6.0 Awareness, Zero-Downtime Rules & DX
+
+Tracking issue: [#30](https://github.com/YasserShkeir/django-safe-migrations/issues/30).
+This plan refines the original SM037–SM057 wishlist (see `v0.6.0.md`) after a
+per-rule feasibility review against **installed Django 6.0** and the current
+codebase (v0.6.3, rules SM001–SM036). It records what ships, what is dropped,
+the shared infrastructure required, and a phased, PR-sized batching.
+
+> Status: planned. Nothing here has shipped yet. Each batch lands as its own
+> CI-gated PR; v0.7.0 is cut once the rule set + high-priority features land.
+
+______________________________________________________________________
+
+## Decisions at a glance
+
+### Ship — 10 new rules + 1 enhancement
+
+| Rule  | Name                               | Severity | Vendor | Django | FP  |
+| ----- | ---------------------------------- | -------- | ------ | ------ | --- |
+| SM037 | `direct_model_import_in_runpython` | INFO¹    | all    | all    | low |
+| SM038 | `mixed_schema_and_data_operations` | WARNING  | all    | all    | med |
+| SM040 | `volatile_default_with_unique`     | ERROR    | all    | all    | low |
+| SM041 | `adding_stored_generated_field`    | WARNING  | all    | 5.0+   | low |
+| SM047 | `constraint_missing_not_valid`     | WARNING  | pg     | all    | med |
+| SM048 | `truncate_in_runsql`               | WARNING  | all    | all    | low |
+| SM049 | `transaction_nesting_in_runsql`    | ERROR    | all    | all    | low |
+| SM050 | `drop_database_in_runsql`          | ERROR    | all    | all    | low |
+| SM054 | `multiple_heavy_ops_same_table`    | INFO     | all    | all    | med |
+| SM056 | `adding_exclusion_constraint`      | WARNING  | pg     | 4.1+   | low |
+| SM057 | `smart_column_type_changes`        | —        | pg     | all    | low |
+
+¹ Downgraded from the roadmap's ERROR: detection is heuristic (source
+inspection), so INFO keeps it advisory and low-noise.
+**SM057 is not a new rule** — it is an allowlist enhancement *inside* SM004 that
+suppresses false positives for known-safe PostgreSQL type widenings
+(`varchar(n)`→`varchar(m)` m>n, `varchar`→`text`, `int`→`bigint`, numeric
+precision increases). It only ever moves cases warn→safe.
+
+### Defer — revisit after the core batch (need a judgement call)
+
+| Rule                                       | Why deferred                                                                                                                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SM039 `remove_field_without_state_split`   | High FP; `RemoveField` without `SeparateDatabaseAndState` is the *normal* way to drop a field, and SM002/SM003 already warn. **Likely outcome:** fold the expand/contract + `SeparateDatabaseAndState` advice into SM002/SM003 suggestions rather than ship a noisy rule. |
+| SM042 `alter_composite_primary_key` (5.2+) | Feasible (detect `CompositePrimaryKey` in AlterField), but the *supported* initial definition can also surface as AlterField → FP risk. Ship only with a tight guard + thorough 5.2 tests.                                                                                |
+| SM045 `volatile_db_default` (5.0+)         | Technically correct (volatile `db_default` rewrites the table), but **contradicts SM022/SM033**, which recommend `db_default=Now()`. Reconcile the messaging first.                                                                                                       |
+| SM051 `recommend_db_default` (5.0+)        | Heavy overlap with SM033; would double-report. Only ship if coordinated so one operation yields one message.                                                                                                                                                              |
+| SM055 `unnecessary_atomic_false`           | High FP — `atomic=False` has many legitimate uses the rule can't see (batched RunPython, internal `transaction.atomic()`). Ship only as a conservative INFO that fires when *no* operation needs non-atomic.                                                              |
+
+### Drop — verified redundant or infeasible
+
+| Rule                                      | Reason                                                                                                                                                                                                                              |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SM043 `autofield_to_bigautofield_rewrite` | SM004 **already** fires on `AutoField`→`BigAutoField` (type change). Would double-warn. Fold a note into SM004's message instead.                                                                                                   |
+| SM044 `remove_field_no_cascade`           | **Premise is false.** Django 6.0's `RemoveField` emits a plain `ALTER TABLE … DROP COLUMN` (no `CASCADE`) — it never cascaded at the column level. The `DeleteModel`/`DROP TABLE CASCADE` angle is already SM003.                   |
+| SM046 `rename_field_without_db_column`    | Near-total overlap with SM006; `RenameField` carries only `old_name`/`new_name` (no `db_column`), and the intended semantics are inverted.                                                                                          |
+| SM052 `deprecated_check_constraint_check` | `CheckConstraint(check=…)` is **removed in Django 6.0** and was never introspectable from the operation object; detecting it needs raw-AST access the analyzer doesn't provide, and `check=` substring matching is highly FP-prone. |
+| SM053 `prefer_bigint_over_smallint`       | 100% duplicate of SM028, whose `SMALL_PK_TYPES` already includes `SmallAutoField`/`SmallIntegerField`.                                                                                                                              |
+
+### Features
+
+- **Already done:** PostGIS vendor normalization — `utils.get_db_vendor()`
+  already maps `postgis`→`postgresql`. Remove from the roadmap.
+- **High priority:** pyproject.toml config · `--database-vendor` override (+
+  `DATABASE_VENDOR` / `TARGET_DB_VERSION` settings) · selective
+  `--warnings-as-errors` · lint-on-`makemigrations` · migrate-blocking system
+  check (`BLOCK_UNSAFE`).
+- **Medium priority:** `--since-commit` · lint result caching · reverse-migration
+  safety (`--check-reverse`) · deployment-phase classification
+  (`--classify-phase`) · GitHub PR-comment reporter.
+
+______________________________________________________________________
+
+## Phase 0 — Shared infrastructure (unblocks the rest)
+
+1. **Django-version gating.** Add an optional `django_min_version: tuple | None`
+   class attribute to `BaseRule` and an `applies_to_django()` method comparing
+   `django.VERSION`; the analyzer skips a rule whose minimum exceeds the
+   installed Django (mirrors the existing `applies_to_db()` gate). Replaces the
+   ad-hoc `if django.VERSION >= …` pattern (SM034). Needed by SM041 (and SM042/
+   SM045/SM051 if they survive).
+2. **Migration-level rule hook.** SM038/SM054 (and SM055) reason over *all*
+   operations, but `check()` is per-operation. Add an optional
+   `check_migration(self, migration) -> list[Issue]` that the analyzer calls
+   **once per migration**. Cleaner than the `operation is migration.operations[0]`
+   self-gate. Keep `check()` for per-op rules unchanged.
+3. **`inside_sds` context.** When the analyzer recurses into
+   `SeparateDatabaseAndState.database_operations`, pass `inside_sds=True` into
+   `check()` so SDS-aware rules don't have to re-scan by identity. (Only needed
+   if SM039 is revived.)
+4. **Shared helpers:** a SCHEMA/DATA operation classifier and a model-name
+   normalizer (SM038/SM054); a constant-vs-volatile `db_default` helper
+   (`not hasattr(dd, 'resolve_expression') or isinstance(dd, Value)`); lazy/
+   guarded imports for `GeneratedField`, `CompositePrimaryKey`,
+   `ExclusionConstraint` (so 3.2/4.2 still import the package).
+
+______________________________________________________________________
+
+## Batches (each = one CI-gated PR)
+
+- **Batch 1 — RunSQL safety rules** (`run_sql.py`, low risk): SM048, SM050,
+  SM049, SM047. All reuse `_split_sql_statements`; keyword rules anchor with
+  `re.match` at statement start to dodge comment/literal FPs; SM049 gates on
+  `migration.atomic`; SM047 is PostgreSQL-only.
+- **Batch 2 — Field rules** (`add_field.py`/`alter_field.py`): SM040, SM041,
+  SM056, and SM057 (the SM004 safe-conversion allowlist). *Depends on Phase 0
+  (version gate for SM041).*
+- **Batch 3 — RunPython + migration structure**: SM037 (`run_sql.py`), SM038 +
+  SM054 (new `rules/migration_structure.py`). *Depends on Phase 0 (migration
+  hook + classifiers).*
+- **Batch 4 — Decision rules**: evaluate and ship-or-drop SM042, SM045, SM051,
+  SM055, SM039 per the "Defer" notes. Each that survives gets the same DoD.
+- **Batch 5 — Features (high priority)**: pyproject.toml config; `--database-vendor`
+  - `DATABASE_VENDOR`/`TARGET_DB_VERSION`; selective `--warnings-as-errors`;
+    lint-on-`makemigrations`; migrate-blocking system check.
+- **Batch 6 — Features (medium priority)**: `--since-commit`; lint caching;
+  `--check-reverse`; `--classify-phase`; GitHub PR-comment reporter.
+- **Batch 7 — Docs + release**: sync every doc to the new rule count and
+  features (README rules table + "N built-in rules", `docs/rules.md`,
+  `docs/configuration.md` category table, `docs/detected-patterns.md`,
+  `docs/index.md`, `docs/ci_integration.md`, `docs/configuration.md`), update
+  CHANGELOG, bump to **0.7.0**, tag → publish.
+
+### Definition of done (per rule)
+
+Rule class in the right file · registered in `rules/__init__.py` `ALL_RULES` ·
+added to ≥1 `conf.py` category · unit tests (real + safe + edge cases, ~3–5) ·
+`docs/rules.md` section + README rules-table row · CHANGELOG entry · full suite
+
+- pre-commit green on the Python/Django matrix.
+
+______________________________________________________________________
+
+## Notes & risks
+
+- **Rule-ID gaps are fine.** Dropped IDs (SM043, SM044, SM046, SM052, SM053) are
+  retired/reserved, not reused. The shipped set keeps its roadmap IDs.
+- **False positives are the main risk.** Every rule above carries an explicit FP
+  assessment; INFO is preferred for heuristic rules, and migration-level rules
+  must gate DATA detection on a leading-DML keyword (not substring) and count
+  only genuinely heavy ops.
+- **Version-matrix testing.** Version-gated rules (SM041, etc.) must be tested so
+  they no-op on Django < min and fire on ≥ min; the CI matrix already spans
+  3.2–6.0.
+- **Severity changes from the roadmap** (SM037 ERROR→INFO, SM048 ERROR→WARNING)
+  are deliberate noise-reduction choices.


### PR DESCRIPTION
Adds `docs/roadmap/v0.7.0.md` — the implementation-ready v0.7.0 plan, refined from the original SM037–SM057 wishlist after verifying each rule against **installed Django 6.0** and the current codebase.

**Decisions:** 10 new rules + 1 SM004 enhancement to ship; **5 dropped** (SM043/044/046/052/053 — redundant or infeasible, with rationale); **5 deferred** (SM039/042/045/051/055 — need a judgement call). PostGIS support is already done. Several severities downgraded to cut noise.

**Phase 0 infra:** `django_min_version` gate on BaseRule; a migration-level `check_migration()` hook; shared op classifiers. Then PR-sized batches (RunSQL rules → field rules → structure rules → decision rules → features → docs/release), each with a per-rule definition of done.

Tracked as an 18-item task backlog. Tracking issue: #30.