### PR TITLE
feat: v0.7.0 rules part 1 — version gating + RunSQL safety rules (SM047–SM050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Django-version gating for rules.** Rules may declare a
+  `django_min_version` and are skipped when the installed Django is older —
+  groundwork for version-specific rules.
+- **SM047** `constraint_missing_not_valid` (WARNING, PostgreSQL): RunSQL that
+  adds a CHECK/FOREIGN KEY constraint without `NOT VALID` scans the whole table
+  under an ACCESS EXCLUSIVE lock.
+- **SM048** `truncate_in_runsql` (WARNING): `TRUNCATE` in a migration deletes
+  all table data (and `CASCADE` deletes from referencing tables).
+- **SM049** `transaction_nesting_in_runsql` (ERROR): explicit
+  `BEGIN`/`COMMIT`/`ROLLBACK` in RunSQL inside an atomic migration creates a
+  nested transaction.
+- **SM050** `drop_database_in_runsql` (ERROR): `DROP DATABASE`/`DROP SCHEMA` in
+  a migration is catastrophic.
+
 ## [0.6.3] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,44 +27,48 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 
 ## Rules
 
-| Rule ID | Name                               | Severity | Description                                                 |
-| ------- | ---------------------------------- | -------- | ----------------------------------------------------------- |
-| SM001   | `not_null_without_default`         | ERROR    | Adding NOT NULL column without default will lock table      |
-| SM002   | `drop_column_unsafe`               | WARNING  | Dropping column while old code may reference it             |
-| SM003   | `drop_table_unsafe`                | WARNING  | Dropping table while old code may reference it              |
-| SM004   | `alter_column_type`                | WARNING  | Changing column type may rewrite table                      |
-| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks) (PostgreSQL)  |
-| SM006   | `rename_column`                    | INFO     | Column rename may break old code during deployment          |
-| SM007   | `run_sql_unsafe`                   | WARNING  | RunSQL without reverse_sql is not reversible                |
-| SM008   | `large_data_migration`             | INFO     | Data migration may be slow on large tables                  |
-| SM009   | `add_unique_constraint`            | ERROR    | Adding unique constraint requires full table scan           |
-| SM010   | `index_not_concurrent`             | ERROR    | Index creation without CONCURRENTLY (PostgreSQL)            |
-| SM011   | `unique_constraint_not_concurrent` | ERROR    | Unique constraint without concurrent index                  |
-| SM012   | `enum_add_value_transaction`       | ERROR    | Adding enum value inside transaction (PostgreSQL)           |
-| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table (PostgreSQL)       |
-| SM014   | `rename_model`                     | WARNING  | Model rename may break FKs and external references          |
-| SM015   | `alter_unique_together`            | WARNING  | Deprecated in favor of UniqueConstraint                     |
-| SM016   | `run_python_no_reverse`            | INFO     | RunPython without reverse_code is not reversible            |
-| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows (PostgreSQL)   |
-| SM018   | `concurrent_in_atomic_migration`   | ERROR    | Concurrent index operations require atomic=False            |
-| SM019   | `reserved_keyword_column`          | INFO     | Column name is a reserved SQL keyword                       |
-| SM020   | `alter_field_null_false`           | ERROR    | AlterField null=False without data backfill                 |
-| SM021   | `alter_field_unique`               | ERROR    | Adding UNIQUE via AlterField on existing data               |
-| SM022   | `expensive_default_callable`       | WARNING  | Default value uses expensive callable (e.g., now())         |
-| SM023   | `add_many_to_many`                 | INFO     | ManyToMany creates junction table (potential locks)         |
-| SM024   | `sql_injection_pattern`            | ERROR    | SQL injection patterns detected in RunSQL                   |
-| SM025   | `fk_without_index`                 | WARNING  | Foreign key without db_index on large tables                |
-| SM026   | `run_python_no_batching`           | WARNING  | RunPython using .all() without batching                     |
-| SM027   | `missing_merge_migration`          | ERROR    | Multiple leaf migrations need merge migration               |
-| SM028   | `prefer_bigint_over_int`           | WARNING  | Prefer BigAutoField over 32-bit AutoField primary keys      |
-| SM029   | `drop_not_null`                    | WARNING  | Dropping NOT NULL constraint may allow unintended NULLs     |
-| SM030   | `require_concurrent_index_delete`  | ERROR    | Index removal without CONCURRENTLY locks table (PostgreSQL) |
-| SM031   | `prefer_text_over_varchar`         | INFO     | Consider TextField over CharField on PostgreSQL             |
-| SM032   | `prefer_timestamptz`               | INFO     | DateTimeField without USE_TZ stores naive datetimes         |
-| SM033   | `adding_field_with_default`        | WARNING  | NOT NULL field with Python default rewrites all rows        |
-| SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)      |
-| SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                       |
-| SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                    |
+| Rule ID | Name                               | Severity | Description                                                     |
+| ------- | ---------------------------------- | -------- | --------------------------------------------------------------- |
+| SM001   | `not_null_without_default`         | ERROR    | Adding NOT NULL column without default will lock table          |
+| SM002   | `drop_column_unsafe`               | WARNING  | Dropping column while old code may reference it                 |
+| SM003   | `drop_table_unsafe`                | WARNING  | Dropping table while old code may reference it                  |
+| SM004   | `alter_column_type`                | WARNING  | Changing column type may rewrite table                          |
+| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks) (PostgreSQL)      |
+| SM006   | `rename_column`                    | INFO     | Column rename may break old code during deployment              |
+| SM007   | `run_sql_unsafe`                   | WARNING  | RunSQL without reverse_sql is not reversible                    |
+| SM008   | `large_data_migration`             | INFO     | Data migration may be slow on large tables                      |
+| SM009   | `add_unique_constraint`            | ERROR    | Adding unique constraint requires full table scan               |
+| SM010   | `index_not_concurrent`             | ERROR    | Index creation without CONCURRENTLY (PostgreSQL)                |
+| SM011   | `unique_constraint_not_concurrent` | ERROR    | Unique constraint without concurrent index                      |
+| SM012   | `enum_add_value_transaction`       | ERROR    | Adding enum value inside transaction (PostgreSQL)               |
+| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table (PostgreSQL)           |
+| SM014   | `rename_model`                     | WARNING  | Model rename may break FKs and external references              |
+| SM015   | `alter_unique_together`            | WARNING  | Deprecated in favor of UniqueConstraint                         |
+| SM016   | `run_python_no_reverse`            | INFO     | RunPython without reverse_code is not reversible                |
+| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows (PostgreSQL)       |
+| SM018   | `concurrent_in_atomic_migration`   | ERROR    | Concurrent index operations require atomic=False                |
+| SM019   | `reserved_keyword_column`          | INFO     | Column name is a reserved SQL keyword                           |
+| SM020   | `alter_field_null_false`           | ERROR    | AlterField null=False without data backfill                     |
+| SM021   | `alter_field_unique`               | ERROR    | Adding UNIQUE via AlterField on existing data                   |
+| SM022   | `expensive_default_callable`       | WARNING  | Default value uses expensive callable (e.g., now())             |
+| SM023   | `add_many_to_many`                 | INFO     | ManyToMany creates junction table (potential locks)             |
+| SM024   | `sql_injection_pattern`            | ERROR    | SQL injection patterns detected in RunSQL                       |
+| SM025   | `fk_without_index`                 | WARNING  | Foreign key without db_index on large tables                    |
+| SM026   | `run_python_no_batching`           | WARNING  | RunPython using .all() without batching                         |
+| SM027   | `missing_merge_migration`          | ERROR    | Multiple leaf migrations need merge migration                   |
+| SM028   | `prefer_bigint_over_int`           | WARNING  | Prefer BigAutoField over 32-bit AutoField primary keys          |
+| SM029   | `drop_not_null`                    | WARNING  | Dropping NOT NULL constraint may allow unintended NULLs         |
+| SM030   | `require_concurrent_index_delete`  | ERROR    | Index removal without CONCURRENTLY locks table (PostgreSQL)     |
+| SM031   | `prefer_text_over_varchar`         | INFO     | Consider TextField over CharField on PostgreSQL                 |
+| SM032   | `prefer_timestamptz`               | INFO     | DateTimeField without USE_TZ stores naive datetimes             |
+| SM033   | `adding_field_with_default`        | WARNING  | NOT NULL field with Python default rewrites all rows            |
+| SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)          |
+| SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                           |
+| SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                        |
+| SM047   | `constraint_missing_not_valid`     | WARNING  | RunSQL ADD CONSTRAINT (CHECK/FK) without NOT VALID (PostgreSQL) |
+| SM048   | `truncate_in_runsql`               | WARNING  | TRUNCATE in a migration deletes all table data                  |
+| SM049   | `transaction_nesting_in_runsql`    | ERROR    | Explicit BEGIN/COMMIT/ROLLBACK in RunSQL in an atomic migration |
+| SM050   | `drop_database_in_runsql`          | ERROR    | DROP DATABASE/SCHEMA in a migration is catastrophic             |
 
 ## Installation
 

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -232,6 +232,10 @@ class MigrationAnalyzer:
             if not rule.applies_to_db(self.db_vendor):
                 continue
 
+            # Skip rules that require a newer Django than is installed
+            if not rule.applies_to_django():
+                continue
+
             # Check for inline suppression comments
             if file_path and operation_line:
                 if is_operation_suppressed(

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -67,13 +67,22 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM030",
         "SM031",
         "SM034",
+        "SM047",
     ],
     "mysql": [],  # Currently no MySQL-specific rules
     "sqlite": [],  # Currently no SQLite-specific rules
     # Operation type categories
     "indexes": ["SM010", "SM011", "SM018", "SM021", "SM030"],
-    "constraints": ["SM009", "SM011", "SM015", "SM017", "SM020", "SM021"],
-    "destructive": ["SM002", "SM003", "SM009"],
+    "constraints": [
+        "SM009",
+        "SM011",
+        "SM015",
+        "SM017",
+        "SM020",
+        "SM021",
+        "SM047",
+    ],
+    "destructive": ["SM002", "SM003", "SM009", "SM048", "SM050"],
     "relations": ["SM005", "SM023", "SM025"],
     # Safety concern categories
     "locking": [
@@ -85,9 +94,10 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM020",
         "SM021",
         "SM030",
+        "SM047",
     ],
-    "data-loss": ["SM002", "SM003", "SM009", "SM029"],
-    "reversibility": ["SM007", "SM016", "SM017"],
+    "data-loss": ["SM002", "SM003", "SM009", "SM029", "SM048", "SM050"],
+    "reversibility": ["SM007", "SM016", "SM017", "SM049"],
     "data-migrations": ["SM007", "SM008", "SM016", "SM017", "SM022", "SM026"],
     "security": ["SM024"],
     # Severity-based categories
@@ -103,6 +113,8 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM024",
         "SM027",
         "SM030",
+        "SM049",
+        "SM050",
     ],
     "informational": [
         "SM006",

--- a/django_safe_migrations/rules/__init__.py
+++ b/django_safe_migrations/rules/__init__.py
@@ -46,6 +46,8 @@ from django_safe_migrations.rules.remove_field import (
     DropTableUnsafeRule,
 )
 from django_safe_migrations.rules.run_sql import (
+    ConstraintMissingNotValidRule,
+    DropDatabaseInRunSQLRule,
     EnumAddValueInTransactionRule,
     LargeDataMigrationRule,
     PreferIfExistsRule,
@@ -54,6 +56,8 @@ from django_safe_migrations.rules.run_sql import (
     RunPythonWithoutReverseRule,
     RunSQLWithoutReverseRule,
     SQLInjectionPatternRule,
+    TransactionNestingInRunSQLRule,
+    TruncateInRunSQLRule,
 )
 
 __all__ = [
@@ -106,6 +110,10 @@ __all__ = [
     "PreferIdentityRule",
     "RequireLockTimeoutRule",
     "PreferIfExistsRule",
+    "TruncateInRunSQLRule",
+    "DropDatabaseInRunSQLRule",
+    "TransactionNestingInRunSQLRule",
+    "ConstraintMissingNotValidRule",
     # Functions
     "get_all_rules",
     "get_rules_for_db",
@@ -161,6 +169,10 @@ ALL_RULES: list[type[BaseRule]] = [
     PreferIdentityRule,  # SM034
     RequireLockTimeoutRule,  # SM035
     PreferIfExistsRule,  # SM036
+    ConstraintMissingNotValidRule,  # SM047
+    TruncateInRunSQLRule,  # SM048
+    TransactionNestingInRunSQLRule,  # SM049
+    DropDatabaseInRunSQLRule,  # SM050
 ]
 
 logger = logging.getLogger("django_safe_migrations")

--- a/django_safe_migrations/rules/base.py
+++ b/django_safe_migrations/rules/base.py
@@ -94,6 +94,8 @@ class BaseRule(ABC):
     severity: Severity
     description: str
     db_vendors: list[str] = []  # Empty means all databases
+    # Minimum Django version this rule applies to, e.g. (5, 0). None = all.
+    django_min_version: Optional[tuple[int, ...]] = None
 
     @abstractmethod
     def check(
@@ -137,6 +139,19 @@ class BaseRule(ABC):
         if not self.db_vendors:
             return True
         return db_vendor in self.db_vendors
+
+    def applies_to_django(self) -> bool:
+        """Check if this rule applies to the installed Django version.
+
+        Returns:
+            True if ``django_min_version`` is None or the installed Django is
+            at least that version, False otherwise.
+        """
+        if self.django_min_version is None:
+            return True
+        import django
+
+        return django.VERSION[: len(self.django_min_version)] >= self.django_min_version
 
     def create_issue(
         self,

--- a/django_safe_migrations/rules/run_sql.py
+++ b/django_safe_migrations/rules/run_sql.py
@@ -882,3 +882,169 @@ class PreferIfExistsRule(BaseRule):
 
 This makes migrations idempotent and safe to re-run.
 """
+
+
+class TruncateInRunSQLRule(BaseRule):
+    """Detect TRUNCATE in RunSQL.
+
+    ``TRUNCATE TABLE`` deletes all rows in a table, and ``TRUNCATE ... CASCADE``
+    also deletes rows from every referencing table. Putting it in a migration
+    is almost always a mistake and is unrecoverable.
+    """
+
+    rule_id = "SM048"
+    severity = Severity.WARNING
+    description = "TRUNCATE in a migration deletes all table data"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag a RunSQL statement that starts with TRUNCATE."""
+        if not isinstance(operation, migrations.RunSQL):
+            return None
+
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            if re.match(r"TRUNCATE\b", statement, re.IGNORECASE):
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        "RunSQL contains TRUNCATE, which deletes all data in the "
+                        "table. TRUNCATE ... CASCADE also deletes data from "
+                        "referencing tables. Avoid TRUNCATE in migrations; delete "
+                        "rows explicitly (and reversibly) if data removal is "
+                        "intended."
+                    ),
+                )
+        return None
+
+
+class DropDatabaseInRunSQLRule(BaseRule):
+    """Detect DROP DATABASE / DROP SCHEMA in RunSQL.
+
+    Dropping a database or schema from a migration is catastrophic and
+    irreversible; it should never appear in a migration.
+    """
+
+    rule_id = "SM050"
+    severity = Severity.ERROR
+    description = "DROP DATABASE/SCHEMA in a migration is catastrophic"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag a RunSQL statement that starts with DROP DATABASE/SCHEMA."""
+        if not isinstance(operation, migrations.RunSQL):
+            return None
+
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            if re.match(r"DROP\s+(DATABASE|SCHEMA)\b", statement, re.IGNORECASE):
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        "RunSQL contains DROP DATABASE/SCHEMA, which destroys the "
+                        "database or schema and all of its objects. This must not "
+                        "run as part of a migration."
+                    ),
+                )
+        return None
+
+
+class TransactionNestingInRunSQLRule(BaseRule):
+    """Detect explicit transaction control in RunSQL inside an atomic migration.
+
+    Django wraps atomic migrations in a transaction. Issuing ``BEGIN``,
+    ``COMMIT``, ``ROLLBACK``, or ``START TRANSACTION`` inside RunSQL then creates
+    a nested transaction, which PostgreSQL does not truly support — the
+    statements either error or leave the surrounding transaction in an
+    unexpected state.
+    """
+
+    rule_id = "SM049"
+    severity = Severity.ERROR
+    description = "Explicit transaction control in RunSQL conflicts with atomic"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag transaction-control statements in an atomic migration."""
+        if not isinstance(operation, migrations.RunSQL):
+            return None
+
+        # Only an issue inside the implicit transaction of an atomic migration.
+        if not getattr(migration, "atomic", True):
+            return None
+
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            if re.match(
+                r"(BEGIN|START\s+TRANSACTION|COMMIT|ROLLBACK)\b",
+                statement,
+                re.IGNORECASE,
+            ):
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        "RunSQL contains explicit transaction control "
+                        "(BEGIN/COMMIT/ROLLBACK) inside an atomic migration, which "
+                        "Django already wraps in a transaction. This causes nested "
+                        "transaction errors. Set atomic = False on the migration "
+                        "or remove the explicit transaction statements."
+                    ),
+                )
+        return None
+
+
+class ConstraintMissingNotValidRule(BaseRule):
+    """Detect ADD CONSTRAINT (CHECK / FOREIGN KEY) without NOT VALID.
+
+    On PostgreSQL, adding a CHECK or FOREIGN KEY constraint validates every
+    existing row under an ACCESS EXCLUSIVE lock. The safe pattern adds the
+    constraint ``NOT VALID`` (a quick metadata change), then runs
+    ``VALIDATE CONSTRAINT`` separately under a weaker lock.
+    """
+
+    rule_id = "SM047"
+    severity = Severity.WARNING
+    description = "ADD CONSTRAINT (CHECK/FK) without NOT VALID scans the table"
+    db_vendors = ["postgresql"]
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag ALTER TABLE ... ADD CONSTRAINT ... CHECK/FK without NOT VALID."""
+        if not isinstance(operation, migrations.RunSQL):
+            return None
+
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            upper = statement.upper()
+            if (
+                re.search(r"\bALTER\s+TABLE\b", upper)
+                and re.search(r"\bADD\s+CONSTRAINT\b", upper)
+                and re.search(r"\b(FOREIGN\s+KEY|CHECK)\b", upper)
+                and "NOT VALID" not in upper
+            ):
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        "RunSQL adds a CHECK/FOREIGN KEY constraint without "
+                        "NOT VALID, which scans the whole table under an ACCESS "
+                        "EXCLUSIVE lock. Add the constraint NOT VALID, then run "
+                        "VALIDATE CONSTRAINT in a separate statement/migration."
+                    ),
+                )
+        return None

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ ERROR [SM001] myapp/migrations/0002_add_email.py:15
 
 ## Features
 
-- **36 built-in rules** covering schema changes, locking, data loss, and best practices
+- **40 built-in rules** covering schema changes, locking, data loss, and best practices
 - **Database-aware** rules, including PostgreSQL-specific checks for concurrent indexes, TEXT vs VARCHAR, and IDENTITY columns, plus MySQL- and SQLite-specific categories
 - **Fix suggestions** with safe migration patterns for every issue
 - **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1700,3 +1700,113 @@ migrations.RunSQL(
     reverse_sql="DROP TABLE IF EXISTS myapp_cache;",
 )
 ```
+
+______________________________________________________________________
+
+## SM047: constraint_missing_not_valid
+
+| Field         | Value      |
+| ------------- | ---------- |
+| **Rule ID**   | SM047      |
+| **Severity**  | WARNING    |
+| **Databases** | PostgreSQL |
+
+### What it detects
+
+A `RunSQL` statement that runs `ALTER TABLE ... ADD CONSTRAINT ... CHECK` or
+`... FOREIGN KEY` without `NOT VALID`.
+
+### Why it matters
+
+Adding a CHECK or FOREIGN KEY constraint validates every existing row under an
+ACCESS EXCLUSIVE lock, blocking the table for the duration of the scan.
+
+### Safe pattern
+
+```python
+migrations.RunSQL(
+    sql=[
+        "ALTER TABLE orders ADD CONSTRAINT orders_total_check "
+        "CHECK (total >= 0) NOT VALID;",
+        "ALTER TABLE orders VALIDATE CONSTRAINT orders_total_check;",
+    ],
+    reverse_sql="ALTER TABLE orders DROP CONSTRAINT orders_total_check;",
+)
+```
+
+`NOT VALID` adds the constraint instantly (new rows are checked); the later
+`VALIDATE CONSTRAINT` scans existing rows under a weaker SHARE UPDATE EXCLUSIVE
+lock.
+
+______________________________________________________________________
+
+## SM048: truncate_in_runsql
+
+| Field         | Value   |
+| ------------- | ------- |
+| **Rule ID**   | SM048   |
+| **Severity**  | WARNING |
+| **Databases** | All     |
+
+### What it detects
+
+A `RunSQL` statement that starts with `TRUNCATE`.
+
+### Why it matters
+
+`TRUNCATE` deletes all rows in a table and is not transaction-safe to undo;
+`TRUNCATE ... CASCADE` also deletes rows from every referencing table. This is
+almost never intended inside a migration and is unrecoverable.
+
+### Safe pattern
+
+If you must remove data in a migration, delete rows explicitly and reversibly
+with a data migration, scoped to exactly the rows you mean to remove.
+
+______________________________________________________________________
+
+## SM049: transaction_nesting_in_runsql
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM049 |
+| **Severity**  | ERROR |
+| **Databases** | All   |
+
+### What it detects
+
+Explicit `BEGIN`, `START TRANSACTION`, `COMMIT`, or `ROLLBACK` in a `RunSQL`
+statement when the migration is atomic (the default).
+
+### Why it matters
+
+Django already wraps an atomic migration in a transaction. Issuing your own
+transaction control creates a nested transaction, which PostgreSQL does not
+truly support — the statements error or leave the surrounding transaction in an
+unexpected state.
+
+### Safe pattern
+
+Set `atomic = False` on the migration class if you need manual transaction
+control, or remove the explicit transaction statements and let Django manage
+the transaction.
+
+______________________________________________________________________
+
+## SM050: drop_database_in_runsql
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM050 |
+| **Severity**  | ERROR |
+| **Databases** | All   |
+
+### What it detects
+
+A `RunSQL` statement that starts with `DROP DATABASE` or `DROP SCHEMA`.
+
+### Why it matters
+
+Dropping a database or schema from a migration destroys the database/schema and
+all of its objects. It is catastrophic and irreversible and must never run as
+part of a migration.

--- a/tests/unit/rules/test_base.py
+++ b/tests/unit/rules/test_base.py
@@ -1,0 +1,44 @@
+"""Tests for BaseRule shared behavior (db + Django version gating)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from django_safe_migrations.rules.base import BaseRule, Issue, Severity
+
+
+class _NoopRule(BaseRule):
+    """Minimal concrete rule for exercising the gating helpers."""
+
+    rule_id = "SMTEST"
+    severity = Severity.INFO
+    description = "test"
+
+    def check(self, operation, migration, **kwargs) -> Optional[Issue]:
+        return None
+
+
+class TestAppliesToDjango:
+    """Tests for the django_min_version gate."""
+
+    def test_default_applies_to_all_versions(self):
+        """A rule with no django_min_version applies everywhere."""
+        rule = _NoopRule()
+        assert rule.django_min_version is None
+        assert rule.applies_to_django() is True
+
+    def test_future_version_does_not_apply(self):
+        """A rule requiring a newer Django than installed is skipped."""
+
+        class FutureRule(_NoopRule):
+            django_min_version = (99, 0)
+
+        assert FutureRule().applies_to_django() is False
+
+    def test_past_version_applies(self):
+        """A rule requiring an old Django applies on any supported version."""
+
+        class OldRule(_NoopRule):
+            django_min_version = (3, 2)
+
+        assert OldRule().applies_to_django() is True

--- a/tests/unit/rules/test_extra_rules.py
+++ b/tests/unit/rules/test_extra_rules.py
@@ -224,8 +224,8 @@ class TestAllRulesRegistry:
 
     def test_all_rules_contains_expected_count(self):
         """Test ALL_RULES contains expected number of rules."""
-        # v0.5.0 has 36 built-in rules (SM001-SM036)
-        assert len(ALL_RULES) == 36
+        # SM001-SM036 plus the v0.7.0 RunSQL safety rules SM047-SM050.
+        assert len(ALL_RULES) == 40
 
     def test_all_rules_have_unique_ids(self):
         """Test all rules have unique IDs."""

--- a/tests/unit/rules/test_run_sql_rules.py
+++ b/tests/unit/rules/test_run_sql_rules.py
@@ -1016,3 +1016,151 @@ class TestPreferIfExistsRule:
 
         assert issue is not None
         assert issue.rule_id == "SM036"
+
+
+class TestTruncateInRunSQLRule:
+    """Tests for TruncateInRunSQLRule (SM048)."""
+
+    def test_flags_truncate(self, mock_migration):
+        """TRUNCATE in RunSQL is flagged."""
+        from django_safe_migrations.rules.run_sql import TruncateInRunSQLRule
+
+        rule = TruncateInRunSQLRule()
+        op = migrations.RunSQL(
+            "TRUNCATE TABLE users", reverse_sql=migrations.RunSQL.noop
+        )
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM048"
+
+    def test_ignores_non_truncate(self, mock_migration):
+        """Non-TRUNCATE SQL is not flagged."""
+        from django_safe_migrations.rules.run_sql import TruncateInRunSQLRule
+
+        rule = TruncateInRunSQLRule()
+        op = migrations.RunSQL("DELETE FROM users WHERE id = 1")
+        assert rule.check(op, mock_migration) is None
+
+    def test_ignores_truncate_in_comment(self, mock_migration):
+        """The word TRUNCATE inside a comment must not fire (anchored match)."""
+        from django_safe_migrations.rules.run_sql import TruncateInRunSQLRule
+
+        rule = TruncateInRunSQLRule()
+        op = migrations.RunSQL("-- we will TRUNCATE later\nSELECT 1")
+        assert rule.check(op, mock_migration) is None
+
+    def test_ignores_non_runsql(self, not_null_field_operation, mock_migration):
+        """Non-RunSQL operations are ignored."""
+        from django_safe_migrations.rules.run_sql import TruncateInRunSQLRule
+
+        rule = TruncateInRunSQLRule()
+        assert rule.check(not_null_field_operation, mock_migration) is None
+
+
+class TestDropDatabaseInRunSQLRule:
+    """Tests for DropDatabaseInRunSQLRule (SM050)."""
+
+    def test_flags_drop_database(self, mock_migration):
+        """DROP DATABASE is flagged."""
+        from django_safe_migrations.rules.run_sql import DropDatabaseInRunSQLRule
+
+        rule = DropDatabaseInRunSQLRule()
+        op = migrations.RunSQL("DROP DATABASE production")
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM050"
+        assert issue.severity == Severity.ERROR
+
+    def test_flags_drop_schema(self, mock_migration):
+        """DROP SCHEMA is flagged."""
+        from django_safe_migrations.rules.run_sql import DropDatabaseInRunSQLRule
+
+        rule = DropDatabaseInRunSQLRule()
+        op = migrations.RunSQL("DROP SCHEMA legacy CASCADE")
+        assert rule.check(op, mock_migration) is not None
+
+    def test_ignores_drop_table(self, mock_migration):
+        """DROP TABLE is not this rule's concern."""
+        from django_safe_migrations.rules.run_sql import DropDatabaseInRunSQLRule
+
+        rule = DropDatabaseInRunSQLRule()
+        op = migrations.RunSQL("DROP TABLE temp", reverse_sql=migrations.RunSQL.noop)
+        assert rule.check(op, mock_migration) is None
+
+
+class TestTransactionNestingInRunSQLRule:
+    """Tests for TransactionNestingInRunSQLRule (SM049)."""
+
+    def test_flags_begin_in_atomic(self, mock_migration):
+        """BEGIN inside an atomic migration is flagged."""
+        from django_safe_migrations.rules.run_sql import TransactionNestingInRunSQLRule
+
+        rule = TransactionNestingInRunSQLRule()
+        op = migrations.RunSQL("BEGIN; UPDATE t SET x = 1; COMMIT")
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM049"
+
+    def test_allows_in_non_atomic_migration(self):
+        """Explicit transaction control is allowed when atomic=False."""
+        from django_safe_migrations.rules.run_sql import TransactionNestingInRunSQLRule
+
+        class NonAtomic:
+            app_label = "testapp"
+            name = "0001_test"
+            atomic = False
+
+        rule = TransactionNestingInRunSQLRule()
+        op = migrations.RunSQL("BEGIN; UPDATE t SET x = 1; COMMIT")
+        assert rule.check(op, NonAtomic()) is None
+
+    def test_ignores_case_end(self, mock_migration):
+        """CASE ... END must not be mistaken for transaction control."""
+        from django_safe_migrations.rules.run_sql import TransactionNestingInRunSQLRule
+
+        rule = TransactionNestingInRunSQLRule()
+        op = migrations.RunSQL("UPDATE t SET y = CASE WHEN x THEN 1 ELSE 0 END")
+        assert rule.check(op, mock_migration) is None
+
+
+class TestConstraintMissingNotValidRule:
+    """Tests for ConstraintMissingNotValidRule (SM047)."""
+
+    def test_flags_fk_without_not_valid(self, mock_migration):
+        """ADD CONSTRAINT ... FOREIGN KEY without NOT VALID is flagged."""
+        from django_safe_migrations.rules.run_sql import ConstraintMissingNotValidRule
+
+        rule = ConstraintMissingNotValidRule()
+        op = migrations.RunSQL(
+            "ALTER TABLE orders ADD CONSTRAINT fk_u "
+            "FOREIGN KEY (uid) REFERENCES users(id)"
+        )
+        issue = rule.check(op, mock_migration, db_vendor="postgresql")
+        assert issue is not None
+        assert issue.rule_id == "SM047"
+
+    def test_allows_with_not_valid(self, mock_migration):
+        """A NOT VALID constraint is the safe pattern and is not flagged."""
+        from django_safe_migrations.rules.run_sql import ConstraintMissingNotValidRule
+
+        rule = ConstraintMissingNotValidRule()
+        op = migrations.RunSQL(
+            "ALTER TABLE orders ADD CONSTRAINT c " "CHECK (total >= 0) NOT VALID"
+        )
+        assert rule.check(op, mock_migration, db_vendor="postgresql") is None
+
+    def test_ignores_unique_constraint(self, mock_migration):
+        """A UNIQUE constraint is out of scope (no full validation scan)."""
+        from django_safe_migrations.rules.run_sql import ConstraintMissingNotValidRule
+
+        rule = ConstraintMissingNotValidRule()
+        op = migrations.RunSQL("ALTER TABLE orders ADD CONSTRAINT u UNIQUE (code)")
+        assert rule.check(op, mock_migration, db_vendor="postgresql") is None
+
+    def test_postgresql_only(self):
+        """SM047 is PostgreSQL-only."""
+        from django_safe_migrations.rules.run_sql import ConstraintMissingNotValidRule
+
+        rule = ConstraintMissingNotValidRule()
+        assert rule.applies_to_db("postgresql") is True
+        assert rule.applies_to_db("mysql") is False


### PR DESCRIPTION
First v0.7.0 implementation batch (plan: docs/roadmap/v0.7.0.md, issue #30).

**Phase 0a — Django-version gating:** `BaseRule.django_min_version` + `applies_to_django()`; the analyzer skips rules requiring a newer Django than installed (mirrors `applies_to_db`). Unblocks version-specific rules (SM041 next).

**Batch 1 — RunSQL safety rules** (run_sql.py, reuse `_split_sql_statements`; keyword rules anchor with `re.match` at statement start to dodge comment/literal FPs):
- **SM047** `constraint_missing_not_valid` (WARNING, PostgreSQL)
- **SM048** `truncate_in_runsql` (WARNING)
- **SM049** `transaction_nesting_in_runsql` (ERROR; gated on `migration.atomic`, ignores CASE…END)
- **SM050** `drop_database_in_runsql` (ERROR)

Registered + categorized + 15 rule tests + version-gate test; README rules table, docs/rules.md sections, count 36→40, CHANGELOG. 741 tests pass; pre-commit green. (Comprehensive doc sweep — configuration.md category table etc. — is task #17 before release.)