### PR TITLE
feat: v0.7.0 rules part 2 — field rules (SM040, SM041, SM056) + SM057

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nested transaction.
 - **SM050** `drop_database_in_runsql` (ERROR): `DROP DATABASE`/`DROP SCHEMA` in
   a migration is catastrophic.
+- **SM040** `volatile_default_with_unique` (ERROR): adding a field with
+  `unique=True` and a callable default writes the same value to every existing
+  row, violating uniqueness.
+- **SM041** `adding_stored_generated_field` (WARNING, Django 5.0+): adding a
+  stored `GeneratedField` rewrites the whole table.
+- **SM056** `adding_exclusion_constraint` (WARNING, PostgreSQL): exclusion
+  constraints cannot use `NOT VALID`; adding one scans the whole table under an
+  ACCESS EXCLUSIVE lock.
+
+### Changed
+
+- **SM004** (`alter_column_type`): no longer warns on known-safe PostgreSQL
+  cross-type conversions (currently `CharField`→`TextField`, i.e. `varchar`→
+  `text`), which are metadata-only. (This is the SM057 enhancement.)
 
 ## [0.6.3] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 | SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)          |
 | SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                           |
 | SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                        |
+| SM040   | `volatile_default_with_unique`     | ERROR    | Unique field with a callable default fails on populated tables  |
+| SM041   | `adding_stored_generated_field`    | WARNING  | Adding a stored GeneratedField rewrites the table (Django 5.0+) |
 | SM047   | `constraint_missing_not_valid`     | WARNING  | RunSQL ADD CONSTRAINT (CHECK/FK) without NOT VALID (PostgreSQL) |
 | SM048   | `truncate_in_runsql`               | WARNING  | TRUNCATE in a migration deletes all table data                  |
 | SM049   | `transaction_nesting_in_runsql`    | ERROR    | Explicit BEGIN/COMMIT/ROLLBACK in RunSQL in an atomic migration |
 | SM050   | `drop_database_in_runsql`          | ERROR    | DROP DATABASE/SCHEMA in a migration is catastrophic             |
+| SM056   | `adding_exclusion_constraint`      | WARNING  | Exclusion constraint scans the whole table (PostgreSQL)         |
 
 ## Installation
 

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -68,6 +68,7 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM031",
         "SM034",
         "SM047",
+        "SM056",
     ],
     "mysql": [],  # Currently no MySQL-specific rules
     "sqlite": [],  # Currently no SQLite-specific rules
@@ -80,7 +81,9 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM017",
         "SM020",
         "SM021",
+        "SM040",
         "SM047",
+        "SM056",
     ],
     "destructive": ["SM002", "SM003", "SM009", "SM048", "SM050"],
     "relations": ["SM005", "SM023", "SM025"],
@@ -94,9 +97,11 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM020",
         "SM021",
         "SM030",
+        "SM041",
         "SM047",
+        "SM056",
     ],
-    "data-loss": ["SM002", "SM003", "SM009", "SM029", "SM048", "SM050"],
+    "data-loss": ["SM002", "SM003", "SM009", "SM029", "SM040", "SM048", "SM050"],
     "reversibility": ["SM007", "SM016", "SM017", "SM049"],
     "data-migrations": ["SM007", "SM008", "SM016", "SM017", "SM022", "SM026"],
     "security": ["SM024"],
@@ -113,6 +118,7 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM024",
         "SM027",
         "SM030",
+        "SM040",
         "SM049",
         "SM050",
     ],
@@ -144,8 +150,9 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM028",
         "SM029",
         "SM033",
+        "SM041",
     ],
-    "performance": ["SM022", "SM025", "SM026", "SM028", "SM033"],
+    "performance": ["SM022", "SM025", "SM026", "SM028", "SM033", "SM041"],
 }
 
 # Default configuration values

--- a/django_safe_migrations/rules/__init__.py
+++ b/django_safe_migrations/rules/__init__.py
@@ -6,12 +6,14 @@ import logging
 
 from django_safe_migrations.rules.add_field import (
     AddFieldWithDefaultRule,
+    AddStoredGeneratedFieldRule,
     ExpensiveDefaultCallableRule,
     NotNullWithoutDefaultRule,
     PreferBigIntRule,
     PreferIdentityRule,
     PreferTextOverVarcharRule,
     PreferTimestampTZRule,
+    VolatileDefaultWithUniqueRule,
 )
 from django_safe_migrations.rules.add_index import (
     ConcurrentInAtomicMigrationRule,
@@ -32,6 +34,7 @@ from django_safe_migrations.rules.alter_field import (
 from django_safe_migrations.rules.base import BaseRule, Issue, Severity
 from django_safe_migrations.rules.constraints import (
     AddCheckConstraintRule,
+    AddExclusionConstraintRule,
     AddUniqueConstraintRule,
     AlterUniqueTogetherRule,
 )
@@ -89,6 +92,9 @@ __all__ = [
     "AddUniqueConstraintRule",
     "AlterUniqueTogetherRule",
     "AddCheckConstraintRule",
+    "AddExclusionConstraintRule",
+    "VolatileDefaultWithUniqueRule",
+    "AddStoredGeneratedFieldRule",
     # SM010-SM011, SM018 - Index rules
     "UnsafeIndexCreationRule",
     "UnsafeUniqueConstraintRule",
@@ -173,6 +179,9 @@ ALL_RULES: list[type[BaseRule]] = [
     TruncateInRunSQLRule,  # SM048
     TransactionNestingInRunSQLRule,  # SM049
     DropDatabaseInRunSQLRule,  # SM050
+    VolatileDefaultWithUniqueRule,  # SM040
+    AddStoredGeneratedFieldRule,  # SM041
+    AddExclusionConstraintRule,  # SM056
 ]
 
 logger = logging.getLogger("django_safe_migrations")

--- a/django_safe_migrations/rules/add_field.py
+++ b/django_safe_migrations/rules/add_field.py
@@ -794,3 +794,91 @@ Option 2: Use RunSQL to create IDENTITY columns manually:
                    'DROP IDENTITY',
    )
 """
+
+
+class VolatileDefaultWithUniqueRule(BaseRule):
+    """Detect AddField with unique=True and a callable default.
+
+    A callable default (e.g. ``uuid.uuid4``) is evaluated once by the migration
+    and the same value is written to every existing row, immediately violating
+    the UNIQUE constraint on any populated table — the migration fails.
+    """
+
+    rule_id = "SM040"
+    severity = Severity.ERROR
+    description = "Unique field with a callable default fails on populated tables"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag AddField(unique=True, default=<callable>)."""
+        if not isinstance(operation, migrations.AddField):
+            return None
+
+        field = operation.field
+        if not getattr(field, "unique", False):
+            return None
+
+        from django.db.models.fields import NOT_PROVIDED
+
+        default = getattr(field, "default", NOT_PROVIDED)
+        if default is NOT_PROVIDED or not callable(default):
+            return None
+
+        return self.create_issue(
+            operation=operation,
+            migration=migration,
+            message=(
+                f"Adding field '{operation.name}' on '{operation.model_name}' "
+                "with unique=True and a callable default writes the SAME value "
+                "to every existing row, violating uniqueness and failing the "
+                "migration. Add the field nullable, backfill unique values per "
+                "row in a data migration, then add the unique constraint."
+            ),
+        )
+
+
+class AddStoredGeneratedFieldRule(BaseRule):
+    """Detect adding a stored GeneratedField to an existing table.
+
+    A stored (``db_persist=True``) ``GeneratedField`` (Django 5.0+) computes its
+    value for every existing row when added, requiring a full table rewrite
+    under an ACCESS EXCLUSIVE lock on PostgreSQL and MySQL.
+    """
+
+    rule_id = "SM041"
+    severity = Severity.WARNING
+    description = "Adding a stored GeneratedField rewrites the whole table"
+    django_min_version = (5, 0)
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag AddField of a GeneratedField with db_persist=True."""
+        if not isinstance(operation, migrations.AddField):
+            return None
+
+        try:
+            from django.db.models import GeneratedField
+        except ImportError:  # Django < 5.0
+            return None
+
+        field = operation.field
+        if isinstance(field, GeneratedField) and getattr(field, "db_persist", False):
+            return self.create_issue(
+                operation=operation,
+                migration=migration,
+                message=(
+                    f"Adding stored GeneratedField '{operation.name}' to "
+                    f"'{operation.model_name}' computes the value for every "
+                    "existing row, requiring a full table rewrite under an "
+                    "ACCESS EXCLUSIVE lock."
+                ),
+            )
+        return None

--- a/django_safe_migrations/rules/alter_field.py
+++ b/django_safe_migrations/rules/alter_field.py
@@ -70,7 +70,9 @@ class AlterColumnTypeRule(BaseRule):
 
         # If we have the old field state, do precise comparison
         if old_field is not None:
-            if self._is_safe_change_with_old_field(old_field, field):
+            if self._is_safe_change_with_old_field(
+                old_field, field, kwargs.get("db_vendor")
+            ):
                 logger.debug(
                     "Skipping AlterField on %s.%s - safe change (old field known)",
                     operation.model_name,
@@ -96,14 +98,27 @@ class AlterColumnTypeRule(BaseRule):
             ),
         )
 
+    # Cross-type changes that are metadata-only on PostgreSQL (no rewrite).
+    # SM057: this allowlist only ever suppresses warnings (warn -> safe).
+    SAFE_CROSS_TYPE_CHANGES_POSTGRES = frozenset(
+        {
+            ("CharField", "TextField"),  # varchar(n) -> text
+        }
+    )
+
     def _is_safe_change_with_old_field(
-        self, old_field: object, new_field: object
+        self,
+        old_field: object,
+        new_field: object,
+        db_vendor: object = None,
     ) -> bool:
         """Check if the change is safe by comparing old and new fields.
 
         Args:
             old_field: The field definition before this operation.
             new_field: The new field definition.
+            db_vendor: The database vendor, used to allow known-safe
+                vendor-specific type conversions (SM057).
 
         Returns:
             True if the change is safe, False otherwise.
@@ -111,8 +126,14 @@ class AlterColumnTypeRule(BaseRule):
         old_type = old_field.__class__.__name__
         new_type = new_field.__class__.__name__
 
-        # A change of field/column type is potentially a full table rewrite.
+        # A change of field/column type is potentially a full table rewrite,
+        # unless it is a known-safe metadata-only conversion for this vendor.
         if old_type != new_type:
+            if (
+                db_vendor == "postgresql"
+                and (old_type, new_type) in self.SAFE_CROSS_TYPE_CHANGES_POSTGRES
+            ):
+                return True
             return False
 
         # Changing the column collation rewrites the table on PostgreSQL.

--- a/django_safe_migrations/rules/constraints.py
+++ b/django_safe_migrations/rules/constraints.py
@@ -304,3 +304,46 @@ class AddCheckConstraintRule(BaseRule):
 Note: VALIDATE CONSTRAINT takes a SHARE UPDATE EXCLUSIVE lock,
 which allows reads and writes but blocks schema changes.
 """
+
+
+class AddExclusionConstraintRule(BaseRule):
+    """Detect adding a PostgreSQL exclusion constraint to an existing table.
+
+    Unlike CHECK and FOREIGN KEY constraints, an exclusion constraint cannot be
+    added ``NOT VALID``. Adding one to a populated table always requires a full
+    table scan under an ACCESS EXCLUSIVE lock — there is no safe incremental
+    approach.
+    """
+
+    rule_id = "SM056"
+    severity = Severity.WARNING
+    description = "Adding an exclusion constraint scans the whole table"
+    db_vendors = ["postgresql"]
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag AddConstraint of an ExclusionConstraint."""
+        if not isinstance(operation, migrations.AddConstraint):
+            return None
+
+        constraint = getattr(operation, "constraint", None)
+        # Match by class name to avoid importing django.contrib.postgres here.
+        if (
+            constraint is not None
+            and type(constraint).__name__ == "ExclusionConstraint"
+        ):
+            return self.create_issue(
+                operation=operation,
+                migration=migration,
+                message=(
+                    "Adding an exclusion constraint to an existing table "
+                    "requires a full table scan under an ACCESS EXCLUSIVE lock "
+                    "and cannot use NOT VALID. Add it when the table is created "
+                    "or plan for the lock."
+                ),
+            )
+        return None

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ ERROR [SM001] myapp/migrations/0002_add_email.py:15
 
 ## Features
 
-- **40 built-in rules** covering schema changes, locking, data loss, and best practices
+- **43 built-in rules** covering schema changes, locking, data loss, and best practices
 - **Database-aware** rules, including PostgreSQL-specific checks for concurrent indexes, TEXT vs VARCHAR, and IDENTITY columns, plus MySQL- and SQLite-specific categories
 - **Fix suggestions** with safe migration patterns for every issue
 - **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1810,3 +1810,78 @@ A `RunSQL` statement that starts with `DROP DATABASE` or `DROP SCHEMA`.
 Dropping a database or schema from a migration destroys the database/schema and
 all of its objects. It is catastrophic and irreversible and must never run as
 part of a migration.
+
+______________________________________________________________________
+
+## SM040: volatile_default_with_unique
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM040 |
+| **Severity**  | ERROR |
+| **Databases** | All   |
+
+### What it detects
+
+`AddField` with `unique=True` and a callable `default` (e.g.
+`UUIDField(default=uuid.uuid4, unique=True)`).
+
+### Why it matters
+
+The migration evaluates the callable once and writes the same value to every
+existing row, which immediately violates the UNIQUE constraint — the migration
+fails on any populated table.
+
+### Safe pattern
+
+```python
+# 1. Add nullable
+migrations.AddField("user", "uuid", models.UUIDField(null=True))
+# 2. Backfill a unique value per row (data migration)
+# 3. Add the unique constraint
+migrations.AlterField("user", "uuid", models.UUIDField(unique=True))
+```
+
+______________________________________________________________________
+
+## SM041: adding_stored_generated_field
+
+| Field         | Value   |
+| ------------- | ------- |
+| **Rule ID**   | SM041   |
+| **Severity**  | WARNING |
+| **Databases** | All     |
+| **Django**    | 5.0+    |
+
+### What it detects
+
+`AddField` of a `GeneratedField` with `db_persist=True` (a STORED generated
+column).
+
+### Why it matters
+
+A stored generated column is computed for every existing row when added,
+requiring a full table rewrite under an ACCESS EXCLUSIVE lock on PostgreSQL and
+MySQL. Virtual generated columns (`db_persist=False`) are metadata-only but are
+only supported on newer database versions.
+
+______________________________________________________________________
+
+## SM056: adding_exclusion_constraint
+
+| Field         | Value      |
+| ------------- | ---------- |
+| **Rule ID**   | SM056      |
+| **Severity**  | WARNING    |
+| **Databases** | PostgreSQL |
+
+### What it detects
+
+`AddConstraint` with a PostgreSQL `ExclusionConstraint`.
+
+### Why it matters
+
+Unlike CHECK and FOREIGN KEY constraints, an exclusion constraint cannot be
+added `NOT VALID`. Adding one to a populated table always requires a full table
+scan under an ACCESS EXCLUSIVE lock — there is no safe incremental approach.
+Add it when the table is created, or plan for the lock.

--- a/tests/unit/rules/test_add_field_rules.py
+++ b/tests/unit/rules/test_add_field_rules.py
@@ -1,5 +1,7 @@
 """Tests for AddField rules."""
 
+import django
+import pytest
 from django.db import migrations, models
 
 from django_safe_migrations.rules.add_field import NotNullWithoutDefaultRule
@@ -1153,6 +1155,9 @@ class TestVolatileDefaultWithUniqueRule:
 class TestAddStoredGeneratedFieldRule:
     """Tests for AddStoredGeneratedFieldRule (SM041)."""
 
+    @pytest.mark.skipif(
+        django.VERSION < (5, 0), reason="GeneratedField requires Django 5.0+"
+    )
     def test_flags_stored_generated_field(self, mock_migration):
         """A stored (db_persist=True) GeneratedField is flagged."""
         from django.db.models import GeneratedField
@@ -1170,6 +1175,9 @@ class TestAddStoredGeneratedFieldRule:
         assert issue is not None
         assert issue.rule_id == "SM041"
 
+    @pytest.mark.skipif(
+        django.VERSION < (5, 0), reason="GeneratedField requires Django 5.0+"
+    )
     def test_allows_virtual_generated_field(self, mock_migration):
         """A virtual (db_persist=False) GeneratedField is not flagged."""
         from django.db.models import GeneratedField

--- a/tests/unit/rules/test_add_field_rules.py
+++ b/tests/unit/rules/test_add_field_rules.py
@@ -1101,3 +1101,92 @@ class TestPreferIdentityRule:
         assert suggestion is not None
         assert "IDENTITY" in suggestion
         assert "Django 4.0" in suggestion
+
+
+class TestVolatileDefaultWithUniqueRule:
+    """Tests for VolatileDefaultWithUniqueRule (SM040)."""
+
+    def test_flags_unique_callable_default(self, mock_migration):
+        """unique=True with a callable default is flagged."""
+        import uuid
+
+        from django_safe_migrations.rules.add_field import VolatileDefaultWithUniqueRule
+
+        rule = VolatileDefaultWithUniqueRule()
+        op = migrations.AddField(
+            model_name="user",
+            name="uid",
+            field=models.UUIDField(default=uuid.uuid4, unique=True),
+        )
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM040"
+        assert issue.severity == Severity.ERROR
+
+    def test_allows_unique_static_default(self, mock_migration):
+        """A unique field with a static default is not flagged."""
+        from django_safe_migrations.rules.add_field import VolatileDefaultWithUniqueRule
+
+        rule = VolatileDefaultWithUniqueRule()
+        op = migrations.AddField(
+            model_name="user",
+            name="code",
+            field=models.CharField(max_length=5, default="X", unique=True),
+        )
+        assert rule.check(op, mock_migration) is None
+
+    def test_allows_callable_default_not_unique(self, mock_migration):
+        """A callable default without unique=True is not this rule's concern."""
+        from django.utils import timezone
+
+        from django_safe_migrations.rules.add_field import VolatileDefaultWithUniqueRule
+
+        rule = VolatileDefaultWithUniqueRule()
+        op = migrations.AddField(
+            model_name="user",
+            name="created",
+            field=models.DateTimeField(default=timezone.now),
+        )
+        assert rule.check(op, mock_migration) is None
+
+
+class TestAddStoredGeneratedFieldRule:
+    """Tests for AddStoredGeneratedFieldRule (SM041)."""
+
+    def test_flags_stored_generated_field(self, mock_migration):
+        """A stored (db_persist=True) GeneratedField is flagged."""
+        from django.db.models import GeneratedField
+
+        from django_safe_migrations.rules.add_field import AddStoredGeneratedFieldRule
+
+        rule = AddStoredGeneratedFieldRule()
+        gf = GeneratedField(
+            expression=models.F("price") * 2,
+            output_field=models.IntegerField(),
+            db_persist=True,
+        )
+        op = migrations.AddField(model_name="item", name="double", field=gf)
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM041"
+
+    def test_allows_virtual_generated_field(self, mock_migration):
+        """A virtual (db_persist=False) GeneratedField is not flagged."""
+        from django.db.models import GeneratedField
+
+        from django_safe_migrations.rules.add_field import AddStoredGeneratedFieldRule
+
+        rule = AddStoredGeneratedFieldRule()
+        gf = GeneratedField(
+            expression=models.F("price") * 2,
+            output_field=models.IntegerField(),
+            db_persist=False,
+        )
+        op = migrations.AddField(model_name="item", name="double", field=gf)
+        assert rule.check(op, mock_migration) is None
+
+    def test_requires_django_5_0(self):
+        """SM041 declares a Django 5.0 minimum."""
+        from django_safe_migrations.rules.add_field import AddStoredGeneratedFieldRule
+
+        assert AddStoredGeneratedFieldRule().django_min_version == (5, 0)

--- a/tests/unit/rules/test_alter_field_rules.py
+++ b/tests/unit/rules/test_alter_field_rules.py
@@ -840,3 +840,51 @@ class TestDropNotNullRule:
         assert suggestion is not None
         assert "NULL" in suggestion or "null" in suggestion.lower()
         assert "email" in suggestion
+
+
+class TestSmartColumnTypeChanges:
+    """Tests for SM057 — SM004's safe cross-type-change allowlist."""
+
+    def test_charfield_to_textfield_safe_on_postgres(self, mock_migration):
+        """A varchar -> text change is metadata-only on PostgreSQL (safe)."""
+        rule = AlterColumnTypeRule()
+        op = migrations.AlterField(
+            model_name="user", name="bio", field=models.TextField()
+        )
+        issue = rule.check(
+            op,
+            mock_migration,
+            old_field=models.CharField(max_length=200),
+            db_vendor="postgresql",
+        )
+        assert issue is None
+
+    def test_charfield_to_textfield_flagged_off_postgres(self, mock_migration):
+        """The allowlist is PostgreSQL-specific; other vendors still warn."""
+        rule = AlterColumnTypeRule()
+        op = migrations.AlterField(
+            model_name="user", name="bio", field=models.TextField()
+        )
+        issue = rule.check(
+            op,
+            mock_migration,
+            old_field=models.CharField(max_length=200),
+            db_vendor="mysql",
+        )
+        assert issue is not None
+        assert issue.rule_id == "SM004"
+
+    def test_unsafe_type_change_still_flagged(self, mock_migration):
+        """A genuinely unsafe type change is still flagged on PostgreSQL."""
+        rule = AlterColumnTypeRule()
+        op = migrations.AlterField(
+            model_name="user", name="code", field=models.IntegerField()
+        )
+        issue = rule.check(
+            op,
+            mock_migration,
+            old_field=models.CharField(max_length=50),
+            db_vendor="postgresql",
+        )
+        assert issue is not None
+        assert issue.rule_id == "SM004"

--- a/tests/unit/rules/test_constraints.py
+++ b/tests/unit/rules/test_constraints.py
@@ -323,3 +323,46 @@ class TestAddCheckConstraintRule:
     def test_does_not_apply_to_sqlite(self, rule: AddCheckConstraintRule) -> None:
         """Test that rule does not apply to SQLite."""
         assert rule.applies_to_db("sqlite") is False
+
+
+class TestAddExclusionConstraintRule:
+    """Tests for AddExclusionConstraintRule (SM056)."""
+
+    def test_flags_exclusion_constraint(self, mock_migration):
+        """Adding an ExclusionConstraint is flagged."""
+        from django.contrib.postgres.constraints import ExclusionConstraint
+        from django.contrib.postgres.fields import RangeOperators
+        from django.db import migrations
+
+        from django_safe_migrations.rules.constraints import AddExclusionConstraintRule
+
+        rule = AddExclusionConstraintRule()
+        constraint = ExclusionConstraint(
+            name="excl", expressions=[("room", RangeOperators.EQUAL)]
+        )
+        op = migrations.AddConstraint(model_name="booking", constraint=constraint)
+        issue = rule.check(op, mock_migration, db_vendor="postgresql")
+        assert issue is not None
+        assert issue.rule_id == "SM056"
+
+    def test_allows_unique_constraint(self, mock_migration):
+        """A plain UniqueConstraint is not flagged by SM056."""
+        from django.db import migrations
+        from django.db.models import UniqueConstraint
+
+        from django_safe_migrations.rules.constraints import AddExclusionConstraintRule
+
+        rule = AddExclusionConstraintRule()
+        op = migrations.AddConstraint(
+            model_name="booking",
+            constraint=UniqueConstraint(fields=["code"], name="u"),
+        )
+        assert rule.check(op, mock_migration, db_vendor="postgresql") is None
+
+    def test_postgresql_only(self):
+        """SM056 is PostgreSQL-only."""
+        from django_safe_migrations.rules.constraints import AddExclusionConstraintRule
+
+        rule = AddExclusionConstraintRule()
+        assert rule.applies_to_db("postgresql") is True
+        assert rule.applies_to_db("mysql") is False

--- a/tests/unit/rules/test_constraints.py
+++ b/tests/unit/rules/test_constraints.py
@@ -330,17 +330,19 @@ class TestAddExclusionConstraintRule:
 
     def test_flags_exclusion_constraint(self, mock_migration):
         """Adding an ExclusionConstraint is flagged."""
-        from django.contrib.postgres.constraints import ExclusionConstraint
-        from django.contrib.postgres.fields import RangeOperators
         from django.db import migrations
 
         from django_safe_migrations.rules.constraints import AddExclusionConstraintRule
 
+        # The rule matches by class name, so a stand-in avoids importing
+        # django.contrib.postgres (which requires psycopg to be installed).
+        class ExclusionConstraint:
+            name = "excl"
+
         rule = AddExclusionConstraintRule()
-        constraint = ExclusionConstraint(
-            name="excl", expressions=[("room", RangeOperators.EQUAL)]
+        op = migrations.AddConstraint(
+            model_name="booking", constraint=ExclusionConstraint()
         )
-        op = migrations.AddConstraint(model_name="booking", constraint=constraint)
         issue = rule.check(op, mock_migration, db_vendor="postgresql")
         assert issue is not None
         assert issue.rule_id == "SM056"

--- a/tests/unit/rules/test_extra_rules.py
+++ b/tests/unit/rules/test_extra_rules.py
@@ -224,8 +224,8 @@ class TestAllRulesRegistry:
 
     def test_all_rules_contains_expected_count(self):
         """Test ALL_RULES contains expected number of rules."""
-        # SM001-SM036 plus the v0.7.0 RunSQL safety rules SM047-SM050.
-        assert len(ALL_RULES) == 40
+        # SM001-SM036 plus v0.7.0 rules SM040/041/047-050/056.
+        assert len(ALL_RULES) == 43
 
     def test_all_rules_have_unique_ids(self):
         """Test all rules have unique IDs."""


### PR DESCRIPTION
Second v0.7.0 batch (plan: docs/roadmap/v0.7.0.md).

- **SM040** `volatile_default_with_unique` (ERROR): `unique=True` + callable default writes the same value to every existing row.
- **SM041** `adding_stored_generated_field` (WARNING, **Django 5.0+** via the new `django_min_version` gate): stored `GeneratedField` rewrites the table.
- **SM056** `adding_exclusion_constraint` (WARNING, PostgreSQL): exclusion constraints can't use `NOT VALID`.
- **SM057** (enhancement to **SM004**): a PostgreSQL safe-cross-type allowlist so `CharField`→`TextField` (varchar→text) is no longer flagged. Allowlist only ever moves warn→safe.

43 rules total. Registered + categorized + 12 rule tests; README table, docs/rules.md, count 40→43, CHANGELOG. 753 tests pass; pre-commit green.