### PR TITLE
feat: v0.7.0 rules part 3 — RunPython import + migration-structure rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Django-version gating for rules.** Rules may declare a
   `django_min_version` and are skipped when the installed Django is older —
   groundwork for version-specific rules.
+- **Migration-level rules.** Rules may implement `check_migration(migration)`,
+  run once per migration over all operations, enabling cross-operation checks.
+- **SM037** `direct_model_import_in_runpython` (INFO): a RunPython function that
+  imports a model directly instead of using `apps.get_model()` breaks on a
+  fresh database.
+- **SM038** `mixed_schema_and_data_operations` (WARNING): mixing schema changes
+  and data operations (RunPython / RunSQL DML) in one migration extends lock
+  duration.
+- **SM054** `multiple_heavy_ops_same_table` (INFO): three or more heavy schema
+  operations on the same table in one migration hold the lock for their
+  combined duration.
 - **SM047** `constraint_missing_not_valid` (WARNING, PostgreSQL): RunSQL that
   adds a CHECK/FOREIGN KEY constraint without `NOT VALID` scans the whole table
   under an ACCESS EXCLUSIVE lock.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,15 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 | SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)          |
 | SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                           |
 | SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                        |
+| SM037   | `direct_model_import_in_runpython` | INFO     | RunPython imports a model directly instead of apps.get_model()  |
+| SM038   | `mixed_schema_and_data_operations` | WARNING  | Migration mixes schema changes with data operations             |
 | SM040   | `volatile_default_with_unique`     | ERROR    | Unique field with a callable default fails on populated tables  |
 | SM041   | `adding_stored_generated_field`    | WARNING  | Adding a stored GeneratedField rewrites the table (Django 5.0+) |
 | SM047   | `constraint_missing_not_valid`     | WARNING  | RunSQL ADD CONSTRAINT (CHECK/FK) without NOT VALID (PostgreSQL) |
 | SM048   | `truncate_in_runsql`               | WARNING  | TRUNCATE in a migration deletes all table data                  |
 | SM049   | `transaction_nesting_in_runsql`    | ERROR    | Explicit BEGIN/COMMIT/ROLLBACK in RunSQL in an atomic migration |
 | SM050   | `drop_database_in_runsql`          | ERROR    | DROP DATABASE/SCHEMA in a migration is catastrophic             |
+| SM054   | `multiple_heavy_ops_same_table`    | INFO     | 3+ heavy schema operations on one table in a migration          |
 | SM056   | `adding_exclusion_constraint`      | WARNING  | Exclusion constraint scans the whole table (PostgreSQL)         |
 
 ## Installation

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -176,6 +176,26 @@ class MigrationAnalyzer:
                         issues=issues,
                     )
 
+        # Migration-level rules: run once per migration over all operations.
+        for rule in self.rules:
+            if not self._is_rule_enabled(rule.rule_id, app_label):
+                continue
+            if not rule.applies_to_db(self.db_vendor):
+                continue
+            if not rule.applies_to_django():
+                continue
+            for issue in rule.check_migration(migration):
+                issue.severity = get_rule_severity_for_app(
+                    issue.rule_id, issue.severity, app_label
+                )
+                if issue.file_path is None:
+                    issue.file_path = file_path
+                if issue.app_label is None:
+                    issue.app_label = app_label
+                if issue.migration_name is None:
+                    issue.migration_name = migration_name
+                issues.append(issue)
+
         logger.debug(
             "Migration %s.%s analysis complete: %d issues found",
             app_label,

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -99,11 +99,21 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM030",
         "SM041",
         "SM047",
+        "SM054",
         "SM056",
     ],
     "data-loss": ["SM002", "SM003", "SM009", "SM029", "SM040", "SM048", "SM050"],
     "reversibility": ["SM007", "SM016", "SM017", "SM049"],
-    "data-migrations": ["SM007", "SM008", "SM016", "SM017", "SM022", "SM026"],
+    "data-migrations": [
+        "SM007",
+        "SM008",
+        "SM016",
+        "SM017",
+        "SM022",
+        "SM026",
+        "SM037",
+        "SM038",
+    ],
     "security": ["SM024"],
     # Severity-based categories
     "high-risk": [
@@ -150,9 +160,10 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM028",
         "SM029",
         "SM033",
+        "SM038",
         "SM041",
     ],
-    "performance": ["SM022", "SM025", "SM026", "SM028", "SM033", "SM041"],
+    "performance": ["SM022", "SM025", "SM026", "SM028", "SM033", "SM041", "SM054"],
 }
 
 # Default configuration values

--- a/django_safe_migrations/rules/__init__.py
+++ b/django_safe_migrations/rules/__init__.py
@@ -39,6 +39,10 @@ from django_safe_migrations.rules.constraints import (
     AlterUniqueTogetherRule,
 )
 from django_safe_migrations.rules.graph import MissingMergeMigrationRule
+from django_safe_migrations.rules.migration_structure import (
+    MixedSchemaAndDataRule,
+    MultipleHeavyOpsSameTableRule,
+)
 from django_safe_migrations.rules.naming import ReservedKeywordColumnRule
 from django_safe_migrations.rules.relations import (
     AddManyToManyRule,
@@ -50,6 +54,7 @@ from django_safe_migrations.rules.remove_field import (
 )
 from django_safe_migrations.rules.run_sql import (
     ConstraintMissingNotValidRule,
+    DirectModelImportInRunPythonRule,
     DropDatabaseInRunSQLRule,
     EnumAddValueInTransactionRule,
     LargeDataMigrationRule,
@@ -120,6 +125,9 @@ __all__ = [
     "DropDatabaseInRunSQLRule",
     "TransactionNestingInRunSQLRule",
     "ConstraintMissingNotValidRule",
+    "DirectModelImportInRunPythonRule",
+    "MixedSchemaAndDataRule",
+    "MultipleHeavyOpsSameTableRule",
     # Functions
     "get_all_rules",
     "get_rules_for_db",
@@ -182,6 +190,9 @@ ALL_RULES: list[type[BaseRule]] = [
     VolatileDefaultWithUniqueRule,  # SM040
     AddStoredGeneratedFieldRule,  # SM041
     AddExclusionConstraintRule,  # SM056
+    DirectModelImportInRunPythonRule,  # SM037
+    MixedSchemaAndDataRule,  # SM038
+    MultipleHeavyOpsSameTableRule,  # SM054
 ]
 
 logger = logging.getLogger("django_safe_migrations")

--- a/django_safe_migrations/rules/base.py
+++ b/django_safe_migrations/rules/base.py
@@ -116,6 +116,22 @@ class BaseRule(ABC):
         """
         raise NotImplementedError
 
+    def check_migration(self, migration: Migration) -> list[Issue]:
+        """Check a whole migration at once (migration-level rules).
+
+        Called once per migration by the analyzer, in addition to the
+        per-operation ``check()``. Override this for rules that reason about
+        all operations together (e.g. mixing schema and data operations).
+        The default returns no issues.
+
+        Args:
+            migration: The migration to check.
+
+        Returns:
+            A list of Issue objects (empty by default).
+        """
+        return []
+
     def get_suggestion(self, operation: Operation) -> Optional[str]:
         """Return a fix suggestion for the operation.
 

--- a/django_safe_migrations/rules/migration_structure.py
+++ b/django_safe_migrations/rules/migration_structure.py
@@ -1,0 +1,160 @@
+"""Migration-level rules that reason over all operations together."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import TYPE_CHECKING, Optional
+
+from django.db import migrations
+
+from django_safe_migrations.rules.base import BaseRule, Issue, Severity
+from django_safe_migrations.rules.run_sql import _split_sql_statements
+
+if TYPE_CHECKING:
+    from django.db.migrations import Migration
+    from django.db.migrations.operations.base import Operation
+
+# Operations that change the database schema.
+_SCHEMA_OP_TYPES = (
+    migrations.AddField,
+    migrations.RemoveField,
+    migrations.AlterField,
+    migrations.RenameField,
+    migrations.AddIndex,
+    migrations.RemoveIndex,
+    migrations.AddConstraint,
+    migrations.RemoveConstraint,
+    migrations.CreateModel,
+    migrations.DeleteModel,
+    migrations.RenameModel,
+)
+
+# Heavy, potentially table-locking schema operations (excludes cheap/metadata
+# ops like RenameField and brand-new CreateModel).
+_HEAVY_OP_TYPES = (
+    migrations.AddField,
+    migrations.RemoveField,
+    migrations.AlterField,
+    migrations.AddIndex,
+    migrations.RemoveIndex,
+    migrations.AddConstraint,
+    migrations.RemoveConstraint,
+)
+
+_DML_RE = re.compile(r"(INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
+
+
+def _is_schema_op(operation: object) -> bool:
+    """Return True if the operation alters the database schema."""
+    return isinstance(operation, _SCHEMA_OP_TYPES)
+
+
+def _is_data_op(operation: object) -> bool:
+    """Return True if the operation manipulates data (RunPython/RunSQL DML)."""
+    if isinstance(operation, migrations.RunPython):
+        return True
+    if isinstance(operation, migrations.RunSQL):
+        for statement in _split_sql_statements(getattr(operation, "sql", "")):
+            if _DML_RE.match(statement):
+                return True
+    return False
+
+
+def _model_key(operation: object) -> str | None:
+    """Return a normalized model identifier for an operation, if any."""
+    name = getattr(operation, "model_name", None) or getattr(operation, "name", None)
+    return str(name).lower() if name else None
+
+
+class MixedSchemaAndDataRule(BaseRule):
+    """Detect a migration that mixes schema changes with data operations.
+
+    Combining schema changes (AddField, AlterField, …) with data operations
+    (RunPython, or RunSQL containing DML) in one migration extends the lock
+    held during the data step and, on PostgreSQL, can raise
+    ``cannot ALTER TABLE because it has pending trigger events``. Split schema
+    and data into separate migrations.
+    """
+
+    rule_id = "SM038"
+    severity = Severity.WARNING
+    description = "Migration mixes schema changes with data operations"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Per-operation check is unused; this is a migration-level rule."""
+        return None
+
+    def check_migration(self, migration: Migration) -> list[Issue]:
+        """Flag a migration that contains both schema and data operations."""
+        operations = getattr(migration, "operations", [])
+        has_schema = any(_is_schema_op(op) for op in operations)
+        has_data = any(_is_data_op(op) for op in operations)
+        if has_schema and has_data:
+            return [
+                Issue(
+                    rule_id=self.rule_id,
+                    severity=self.severity,
+                    operation="Migration",
+                    message=(
+                        "Migration mixes schema changes with data operations "
+                        "(RunPython/RunSQL DML). Split them into separate "
+                        "migrations to reduce lock duration and avoid pending "
+                        "trigger event errors."
+                    ),
+                )
+            ]
+        return []
+
+
+class MultipleHeavyOpsSameTableRule(BaseRule):
+    """Detect several heavy schema operations on the same table in one migration.
+
+    When a migration runs three or more heavy schema operations against the same
+    table, the table lock is held for their combined duration. Splitting them
+    into separate migrations reduces lock time and deadlock risk.
+    """
+
+    rule_id = "SM054"
+    severity = Severity.INFO
+    description = "Several heavy schema operations on one table in a migration"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Per-operation check is unused; this is a migration-level rule."""
+        return None
+
+    def check_migration(self, migration: Migration) -> list[Issue]:
+        """Flag 3+ heavy ops on the same table."""
+        counts: dict[str, int] = defaultdict(int)
+        for op in getattr(migration, "operations", []):
+            if isinstance(op, _HEAVY_OP_TYPES):
+                key = _model_key(op)
+                if key:
+                    counts[key] += 1
+
+        for model, count in counts.items():
+            if count >= 3:
+                return [
+                    Issue(
+                        rule_id=self.rule_id,
+                        severity=self.severity,
+                        operation="Migration",
+                        message=(
+                            f"Migration has {count} heavy schema operations on "
+                            f"'{model}'. The table lock is held for their combined "
+                            "duration — consider splitting into separate "
+                            "migrations."
+                        ),
+                    )
+                ]
+        return []

--- a/django_safe_migrations/rules/run_sql.py
+++ b/django_safe_migrations/rules/run_sql.py
@@ -1048,3 +1048,77 @@ class ConstraintMissingNotValidRule(BaseRule):
                     ),
                 )
         return None
+
+
+def _get_runpython_source(func: object) -> Optional[str]:
+    """Return the dedented source of a RunPython function, or None.
+
+    Mirrors the source-inspection approach used by SM026; returns None when the
+    source is unavailable (lambda, C function, file not on disk).
+    """
+    try:
+        import inspect
+        import textwrap
+
+        return textwrap.dedent(inspect.getsource(func))  # type: ignore[arg-type]
+    except (OSError, TypeError):
+        return None
+
+
+class DirectModelImportInRunPythonRule(BaseRule):
+    """Detect a RunPython function that imports a model directly.
+
+    Using ``from app.models import MyModel`` (or ``import app.models``) inside a
+    RunPython function uses the *current* model class, not the historical
+    version at migration time. It works at first but breaks when the migration
+    later runs against a fresh database. The safe approach is
+    ``apps.get_model('app', 'MyModel')``.
+    """
+
+    rule_id = "SM037"
+    severity = Severity.INFO
+    description = "RunPython should use apps.get_model(), not a direct model import"
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag a RunPython function with an inline model import."""
+        if not isinstance(operation, migrations.RunPython):
+            return None
+
+        funcs = (
+            getattr(operation, "code", None),
+            getattr(operation, "reverse_code", None),
+        )
+        for func in funcs:
+            if func is None:
+                continue
+            source = _get_runpython_source(func)
+            if source is None:
+                continue
+
+            has_model_import = bool(
+                re.search(
+                    r"^\s*from\s+[\w.]+\.models\b\s+import\b", source, re.MULTILINE
+                )
+                or re.search(r"^\s*import\s+[\w.]+\.models\b", source, re.MULTILINE)
+            )
+            # Functions that use apps.get_model are doing it right; only flag a
+            # direct import when get_model is not used, to keep noise low.
+            if has_model_import and "apps.get_model" not in source:
+                func_name = getattr(func, "__name__", "function")
+                return self.create_issue(
+                    operation=operation,
+                    migration=migration,
+                    message=(
+                        f"RunPython function '{func_name}' imports a model "
+                        "directly instead of using apps.get_model(). This uses "
+                        "the current model, not the historical one, and breaks "
+                        "on a fresh database. Use "
+                        "apps.get_model('app_label', 'ModelName')."
+                    ),
+                )
+        return None

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ ERROR [SM001] myapp/migrations/0002_add_email.py:15
 
 ## Features
 
-- **43 built-in rules** covering schema changes, locking, data loss, and best practices
+- **46 built-in rules** covering schema changes, locking, data loss, and best practices
 - **Database-aware** rules, including PostgreSQL-specific checks for concurrent indexes, TEXT vs VARCHAR, and IDENTITY columns, plus MySQL- and SQLite-specific categories
 - **Fix suggestions** with safe migration patterns for every issue
 - **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1885,3 +1885,81 @@ Unlike CHECK and FOREIGN KEY constraints, an exclusion constraint cannot be
 added `NOT VALID`. Adding one to a populated table always requires a full table
 scan under an ACCESS EXCLUSIVE lock — there is no safe incremental approach.
 Add it when the table is created, or plan for the lock.
+
+______________________________________________________________________
+
+## SM037: direct_model_import_in_runpython
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM037 |
+| **Severity**  | INFO  |
+| **Databases** | All   |
+
+### What it detects
+
+A `RunPython` function whose source imports a model directly
+(`from app.models import MyModel`) instead of using
+`apps.get_model('app', 'MyModel')`, and does not call `apps.get_model`.
+
+### Why it matters
+
+A direct import uses the *current* model class rather than the historical
+version at migration time. It works initially but breaks when the migration is
+re-run against a fresh database that applies all migrations in order.
+
+### Safe pattern
+
+```python
+def populate(apps, schema_editor):
+    MyModel = apps.get_model("app", "MyModel")
+    MyModel.objects.filter(...).update(...)
+```
+
+______________________________________________________________________
+
+## SM038: mixed_schema_and_data_operations
+
+| Field         | Value   |
+| ------------- | ------- |
+| **Rule ID**   | SM038   |
+| **Severity**  | WARNING |
+| **Databases** | All     |
+
+### What it detects
+
+A single migration that contains both schema operations (AddField, AlterField,
+…) and data operations (RunPython, or RunSQL containing INSERT/UPDATE/DELETE).
+
+### Why it matters
+
+The data step runs inside the same migration (and often the same transaction)
+as the schema change, extending how long the schema lock is held; on PostgreSQL
+it can raise `cannot ALTER TABLE because it has pending trigger events`.
+
+### Safe pattern
+
+Put the schema change in one migration and the data backfill in a separate
+migration that runs afterward.
+
+______________________________________________________________________
+
+## SM054: multiple_heavy_ops_same_table
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM054 |
+| **Severity**  | INFO  |
+| **Databases** | All   |
+
+### What it detects
+
+Three or more heavy schema operations (AddField, RemoveField, AlterField,
+AddIndex, RemoveIndex, AddConstraint, RemoveConstraint) targeting the same table
+in one migration.
+
+### Why it matters
+
+The table lock is held for the combined duration of all the operations.
+Splitting them into separate migrations shortens each lock window and reduces
+deadlock risk.

--- a/tests/unit/rules/test_extra_rules.py
+++ b/tests/unit/rules/test_extra_rules.py
@@ -224,8 +224,8 @@ class TestAllRulesRegistry:
 
     def test_all_rules_contains_expected_count(self):
         """Test ALL_RULES contains expected number of rules."""
-        # SM001-SM036 plus v0.7.0 rules SM040/041/047-050/056.
-        assert len(ALL_RULES) == 43
+        # SM001-SM036 plus v0.7.0 rules SM037/038/040/041/047-050/054/056.
+        assert len(ALL_RULES) == 46
 
     def test_all_rules_have_unique_ids(self):
         """Test all rules have unique IDs."""

--- a/tests/unit/rules/test_migration_structure_rules.py
+++ b/tests/unit/rules/test_migration_structure_rules.py
@@ -1,0 +1,108 @@
+"""Tests for migration-structure rules (SM038, SM054)."""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+from django_safe_migrations.rules.migration_structure import (
+    MixedSchemaAndDataRule,
+    MultipleHeavyOpsSameTableRule,
+)
+
+
+def _noop(apps, schema_editor):
+    pass
+
+
+class TestMixedSchemaAndDataRule:
+    """Tests for MixedSchemaAndDataRule (SM038)."""
+
+    def test_flags_schema_plus_runpython(self, mock_migration_factory):
+        """A migration with a schema op and a RunPython is flagged."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField(
+                    "user", "email", models.CharField(max_length=50, null=True)
+                ),
+                migrations.RunPython(_noop, migrations.RunPython.noop),
+            ]
+        )
+        issues = MixedSchemaAndDataRule().check_migration(mig)
+        assert len(issues) == 1
+        assert issues[0].rule_id == "SM038"
+
+    def test_flags_schema_plus_runsql_dml(self, mock_migration_factory):
+        """A migration with a schema op and a RunSQL DML is flagged."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField(
+                    "user", "email", models.CharField(max_length=50, null=True)
+                ),
+                migrations.RunSQL("UPDATE app_user SET email = ''"),
+            ]
+        )
+        assert MixedSchemaAndDataRule().check_migration(mig)
+
+    def test_allows_schema_only(self, mock_migration_factory):
+        """A schema-only migration is not flagged."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField(
+                    "user", "email", models.CharField(max_length=50, null=True)
+                ),
+                migrations.AddField(
+                    "user", "phone", models.CharField(max_length=20, null=True)
+                ),
+            ]
+        )
+        assert MixedSchemaAndDataRule().check_migration(mig) == []
+
+    def test_allows_runsql_ddl_with_schema(self, mock_migration_factory):
+        """Pure-DDL RunSQL alongside schema ops is not 'data' (no flag)."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField(
+                    "user", "email", models.CharField(max_length=50, null=True)
+                ),
+                migrations.RunSQL("CREATE INDEX ix ON app_user (email)"),
+            ]
+        )
+        assert MixedSchemaAndDataRule().check_migration(mig) == []
+
+
+class TestMultipleHeavyOpsSameTableRule:
+    """Tests for MultipleHeavyOpsSameTableRule (SM054)."""
+
+    def test_flags_three_heavy_ops_same_table(self, mock_migration_factory):
+        """Three heavy ops on one table are flagged."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField("user", "a", models.IntegerField(null=True)),
+                migrations.AlterField("user", "b", models.IntegerField()),
+                migrations.AddIndex("user", models.Index(fields=["a"], name="ix_a")),
+            ]
+        )
+        issues = MultipleHeavyOpsSameTableRule().check_migration(mig)
+        assert len(issues) == 1
+        assert issues[0].rule_id == "SM054"
+
+    def test_allows_ops_on_different_tables(self, mock_migration_factory):
+        """Heavy ops spread across tables are not flagged."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField("user", "a", models.IntegerField(null=True)),
+                migrations.AddField("order", "b", models.IntegerField(null=True)),
+                migrations.AddField("item", "c", models.IntegerField(null=True)),
+            ]
+        )
+        assert MultipleHeavyOpsSameTableRule().check_migration(mig) == []
+
+    def test_allows_two_heavy_ops(self, mock_migration_factory):
+        """Two heavy ops on one table is below the threshold."""
+        mig = mock_migration_factory(
+            [
+                migrations.AddField("user", "a", models.IntegerField(null=True)),
+                migrations.AlterField("user", "b", models.IntegerField()),
+            ]
+        )
+        assert MultipleHeavyOpsSameTableRule().check_migration(mig) == []

--- a/tests/unit/rules/test_run_sql_rules.py
+++ b/tests/unit/rules/test_run_sql_rules.py
@@ -1164,3 +1164,48 @@ class TestConstraintMissingNotValidRule:
         rule = ConstraintMissingNotValidRule()
         assert rule.applies_to_db("postgresql") is True
         assert rule.applies_to_db("mysql") is False
+
+
+class TestDirectModelImportInRunPythonRule:
+    """Tests for DirectModelImportInRunPythonRule (SM037)."""
+
+    def test_flags_direct_model_import(self, mock_migration):
+        """A RunPython function importing a model directly is flagged."""
+        from django_safe_migrations.rules.run_sql import (
+            DirectModelImportInRunPythonRule,
+        )
+
+        def forward(apps, schema_editor):
+            from myapp.models import User  # noqa: F401  (never executed)
+
+            User.objects.all().update(active=True)
+
+        rule = DirectModelImportInRunPythonRule()
+        op = migrations.RunPython(forward, migrations.RunPython.noop)
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM037"
+
+    def test_allows_apps_get_model(self, mock_migration):
+        """A RunPython function using apps.get_model is not flagged."""
+        from django_safe_migrations.rules.run_sql import (
+            DirectModelImportInRunPythonRule,
+        )
+
+        def forward(apps, schema_editor):
+            user = apps.get_model("myapp", "User")
+            user.objects.all().update(active=True)
+
+        rule = DirectModelImportInRunPythonRule()
+        op = migrations.RunPython(forward, migrations.RunPython.noop)
+        assert rule.check(op, mock_migration) is None
+
+    def test_ignores_non_runpython(self, mock_migration):
+        """Non-RunPython operations are ignored."""
+        from django_safe_migrations.rules.run_sql import (
+            DirectModelImportInRunPythonRule,
+        )
+
+        rule = DirectModelImportInRunPythonRule()
+        op = migrations.RunSQL("SELECT 1")
+        assert rule.check(op, mock_migration) is None


### PR DESCRIPTION
Third v0.7.0 batch.

**Phase 0b — migration-level rule hook:** `BaseRule.check_migration(migration)` runs once per migration over all operations (same enable/db/version gating + issue enrichment as per-op rules).

**Batch 3 rules:**
- **SM037** `direct_model_import_in_runpython` (INFO): a RunPython function importing a model directly instead of `apps.get_model()` breaks on a fresh database (source inspection like SM026).
- **SM038** `mixed_schema_and_data_operations` (WARNING, migration-level): mixing schema changes with RunPython/RunSQL-DML in one migration extends lock duration.
- **SM054** `multiple_heavy_ops_same_table` (INFO, migration-level): 3+ heavy schema ops on the same table.

New `rules/migration_structure.py` with shared schema/data/heavy-op classifiers. **46 rules total.** 13 new tests (incl. end-to-end through the analyzer); README table, docs/rules.md, count 43→46, CHANGELOG. 763 tests pass; pre-commit green.