### PR TITLE
feat: v0.7.0 config features — pyproject.toml, --database-vendor, --warnings-as-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   groundwork for version-specific rules.
 - **Migration-level rules.** Rules may implement `check_migration(migration)`,
   run once per migration over all operations, enabling cross-operation checks.
+- **`pyproject.toml` configuration.** A `[tool.django_safe_migrations]` section
+  is read as an alternative to the `SAFE_MIGRATIONS` Django setting (settings
+  take precedence). Useful for CLI / pre-commit usage. Requires Python 3.11+ or
+  the `tomli` package.
+- **`--database-vendor` / `DATABASE_VENDOR`.** Override the auto-detected
+  database vendor so you can develop on SQLite but lint for PostgreSQL.
+- **`--warnings-as-errors` / `WARNINGS_AS_ERRORS`.** Promote specific
+  warning-level rules to build failures (more granular than `--fail-on-warning`).
 - **SM037** `direct_model_import_in_runpython` (INFO): a RunPython function that
   imports a model directly instead of using `apps.get_model()` breaks on a
   fresh database.

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -221,6 +221,19 @@ Documentation: https://django-safe-migrations.readthedocs.io/
         action="store_true",
         help="Watch migration files for changes and re-run analysis",
     )
+    parser.add_argument(
+        "--database-vendor",
+        choices=["postgresql", "mysql", "sqlite", "mariadb"],
+        default=None,
+        help="Override the detected database vendor for rule analysis",
+    )
+    parser.add_argument(
+        "--warnings-as-errors",
+        type=str,
+        default=None,
+        metavar="SM002,SM003",
+        help="Comma-separated rule IDs whose warnings should fail (exit 1)",
+    )
 
     args: Namespace = parser.parse_args(argv)
 
@@ -242,7 +255,12 @@ Documentation: https://django-safe-migrations.readthedocs.io/
 
     # Import after Django setup
     from django_safe_migrations.analyzer import MigrationAnalyzer
-    from django_safe_migrations.conf import get_fail_on_warning, log_config_warnings
+    from django_safe_migrations.conf import (
+        get_database_vendor,
+        get_fail_on_warning,
+        get_warnings_as_errors,
+        log_config_warnings,
+    )
     from django_safe_migrations.reporters import get_reporter
     from django_safe_migrations.rules.base import Issue, Severity
 
@@ -270,7 +288,14 @@ Documentation: https://django-safe-migrations.readthedocs.io/
         exclude_apps = list(set(exclude_apps + django_apps))
 
     # Create analyzer
-    analyzer = MigrationAnalyzer(verbose=args.verbose)
+    db_vendor_override = args.database_vendor or get_database_vendor()
+    analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=args.verbose)
+
+    warnings_as_errors = set(get_warnings_as_errors())
+    if args.warnings_as_errors:
+        warnings_as_errors.update(
+            rid.strip() for rid in args.warnings_as_errors.split(",") if rid.strip()
+        )
 
     # Collect issues
     issues: list[Issue] = []
@@ -354,8 +379,9 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     fail_on_warning = args.fail_on_warning or get_fail_on_warning()
     errors = [i for i in issues if i.severity == Severity.ERROR]
     warnings = [i for i in issues if i.severity == Severity.WARNING]
+    promoted = [i for i in warnings if i.rule_id in warnings_as_errors]
 
-    if errors:
+    if errors or promoted:
         return 1
     elif warnings and fail_on_warning:
         return 1

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -43,7 +43,8 @@ Example::
 from __future__ import annotations
 
 import logging
-from typing import Any
+from functools import lru_cache
+from typing import Any, Optional
 
 from django.conf import settings
 
@@ -183,7 +184,39 @@ DEFAULTS: dict[str, Any] = {
     "FAIL_ON_WARNING": False,
     "APP_RULES": {},  # Per-app rule configuration
     "EXTRA_RULES": [],  # Custom rule class paths to load
+    "DATABASE_VENDOR": None,  # Override auto-detected DB vendor
+    "WARNINGS_AS_ERRORS": [],  # Rule IDs whose warnings fail the build
 }
+
+
+def _read_pyproject_section(path: str = "pyproject.toml") -> dict[str, Any]:
+    """Read ``[tool.django_safe_migrations]`` from a pyproject.toml file.
+
+    Keys are upper-cased to match the ``SAFE_MIGRATIONS`` setting keys
+    (e.g. ``disabled_rules`` -> ``DISABLED_RULES``). Returns ``{}`` when the
+    file or section is absent, or when no TOML parser is available
+    (Python < 3.11 without ``tomli`` installed).
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python < 3.11
+        try:
+            import tomli as tomllib
+        except ModuleNotFoundError:
+            return {}
+    try:
+        with open(path, "rb") as fh:
+            data = tomllib.load(fh)
+    except (FileNotFoundError, OSError, ValueError):
+        return {}
+    section = data.get("tool", {}).get("django_safe_migrations", {})
+    return {str(key).upper(): value for key, value in section.items()}
+
+
+@lru_cache(maxsize=1)
+def load_pyproject_config() -> dict[str, Any]:
+    """Load the cached ``[tool.django_safe_migrations]`` pyproject config."""
+    return _read_pyproject_section()
 
 
 def get_config() -> dict[str, Any]:
@@ -195,10 +228,24 @@ def get_config() -> dict[str, Any]:
     """
     user_config = getattr(settings, "SAFE_MIGRATIONS", {})
 
+    # Precedence: defaults < pyproject.toml < Django settings.
     config = DEFAULTS.copy()
+    config.update(load_pyproject_config())
     config.update(user_config)
 
     return config
+
+
+def get_database_vendor() -> Optional[str]:
+    """Get the configured database-vendor override, or None for auto-detect."""
+    vendor = get_config().get("DATABASE_VENDOR")
+    return str(vendor) if vendor else None
+
+
+def get_warnings_as_errors() -> list[str]:
+    """Get the list of rule IDs whose warnings should fail the build."""
+    value = get_config().get("WARNINGS_AS_ERRORS", [])
+    return list(value) if value else []
 
 
 def get_disabled_rules() -> list[str]:

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -11,7 +11,9 @@ from django.core.management.base import BaseCommand, CommandParser
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.conf import (
     get_category_for_rule,
+    get_database_vendor,
     get_fail_on_warning,
+    get_warnings_as_errors,
     log_config_warnings,
 )
 from django_safe_migrations.reporters import get_reporter
@@ -132,6 +134,19 @@ class Command(BaseCommand):
             action="store_true",
             help="Watch migration files for changes and re-run analysis",
         )
+        parser.add_argument(
+            "--database-vendor",
+            choices=["postgresql", "mysql", "sqlite", "mariadb"],
+            default=None,
+            help="Override the detected database vendor for rule analysis",
+        )
+        parser.add_argument(
+            "--warnings-as-errors",
+            type=str,
+            default=None,
+            metavar="SM002,SM003",
+            help="Comma-separated rule IDs whose warnings should fail (exit 1)",
+        )
 
     def list_rules(self, output_format: str) -> None:
         """List all available rules.
@@ -238,6 +253,19 @@ class Command(BaseCommand):
         include_django_apps = options["include_django_apps"]
         verbose = options.get("verbose", False)
 
+        # Database-vendor override: CLI flag, else DATABASE_VENDOR setting, else
+        # auto-detect (None).
+        db_vendor_override = options.get("database_vendor") or get_database_vendor()
+
+        # Rule IDs whose warnings should fail the build (CLI + setting).
+        warnings_as_errors = set(get_warnings_as_errors())
+        if options.get("warnings_as_errors"):
+            warnings_as_errors.update(
+                rid.strip()
+                for rid in options["warnings_as_errors"].split(",")
+                if rid.strip()
+            )
+
         # Build exclude list by merging CLI args with settings-level EXCLUDED_APPS
         from django_safe_migrations.conf import get_excluded_apps
 
@@ -256,7 +284,7 @@ class Command(BaseCommand):
             exclude_apps = list(set(exclude_apps + django_apps))
 
         # Create analyzer
-        analyzer = MigrationAnalyzer(verbose=verbose)
+        analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=verbose)
 
         # Collect issues
         issues: list[Issue] = []
@@ -380,8 +408,9 @@ class Command(BaseCommand):
         # Determine exit code
         errors = [i for i in issues if i.severity == Severity.ERROR]
         warnings = [i for i in issues if i.severity == Severity.WARNING]
+        promoted = [i for i in warnings if i.rule_id in warnings_as_errors]
 
-        if errors:
+        if errors or promoted:
             sys.exit(1)
         elif warnings and fail_on_warning:
             sys.exit(1)

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -1630,3 +1630,64 @@ class TestSquashedMigrations:
             if "0027_squashed" in i.get("migration_name", "")
         ]
         assert len(squash_issues) > 0, "Squashed migration 0027 should produce issues"
+
+
+class TestV070ConfigFeatures:
+    """Integration tests for --database-vendor and --warnings-as-errors."""
+
+    def test_warnings_as_errors_promotes_to_failure(self):
+        """A warning whose rule is in --warnings-as-errors causes exit 1."""
+        from unittest.mock import patch
+
+        from django_safe_migrations.rules.base import Issue, Severity
+
+        warning = Issue(
+            rule_id="SM002", severity=Severity.WARNING, operation="op", message="w"
+        )
+        out = StringIO()
+        with patch(
+            "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+            return_value=[warning],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                call_command("check_migrations", warnings_as_errors="SM002", stdout=out)
+        assert exc.value.code == 1
+
+    def test_warning_not_promoted_exits_zero(self):
+        """A warning not listed in --warnings-as-errors does not fail."""
+        from unittest.mock import patch
+
+        from django_safe_migrations.rules.base import Issue, Severity
+
+        warning = Issue(
+            rule_id="SM002", severity=Severity.WARNING, operation="op", message="w"
+        )
+        out = StringIO()
+        with patch(
+            "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+            return_value=[warning],
+        ):
+            try:
+                call_command("check_migrations", warnings_as_errors="SM999", stdout=out)
+                code = 0
+            except SystemExit as e:
+                code = e.code
+        assert code == 0
+
+    def test_database_vendor_override_activates_postgres_rules(self):
+        """--database-vendor=postgresql activates PostgreSQL-only rules."""
+        out = StringIO()
+        try:
+            call_command(
+                "check_migrations",
+                "testapp",
+                format="json",
+                database_vendor="postgresql",
+                stdout=out,
+            )
+        except SystemExit:
+            pass
+        data = json.loads(out.getvalue())
+        rule_ids = {i["rule_id"] for i in data["issues"]}
+        # At least one PostgreSQL-only rule should fire under the override.
+        assert rule_ids & {"SM010", "SM011", "SM031", "SM005", "SM013"}

--- a/tests/unit/test_conf.py
+++ b/tests/unit/test_conf.py
@@ -1315,3 +1315,67 @@ class TestConfigurationEdgeCases:
             warnings = validate_config()
             # Should have at least 4 warnings
             assert len(warnings) >= 4
+
+
+class TestV070Config:
+    """Tests for v0.7.0 config: pyproject, DATABASE_VENDOR, WARNINGS_AS_ERRORS."""
+
+    def test_read_pyproject_section(self, tmp_path):
+        """A [tool.django_safe_migrations] section is parsed and upper-cased."""
+        from django_safe_migrations.conf import _read_pyproject_section
+
+        f = tmp_path / "pyproject.toml"
+        f.write_text(
+            "[tool.django_safe_migrations]\n"
+            'disabled_rules = ["SM006"]\n'
+            'database_vendor = "postgresql"\n'
+        )
+        cfg = _read_pyproject_section(str(f))
+        assert cfg == {
+            "DISABLED_RULES": ["SM006"],
+            "DATABASE_VENDOR": "postgresql",
+        }
+
+    def test_read_pyproject_missing(self):
+        """A missing pyproject file yields an empty config."""
+        from django_safe_migrations.conf import _read_pyproject_section
+
+        assert _read_pyproject_section("/no/such/pyproject.toml") == {}
+
+    def test_settings_win_over_pyproject(self, monkeypatch):
+        """Django settings take precedence over pyproject values."""
+        from django.test import override_settings
+
+        from django_safe_migrations import conf
+
+        monkeypatch.setattr(
+            conf,
+            "load_pyproject_config",
+            lambda: {"DISABLED_RULES": ["SM006"], "DATABASE_VENDOR": "mysql"},
+        )
+        with override_settings(SAFE_MIGRATIONS={"DATABASE_VENDOR": "postgresql"}):
+            cfg = conf.get_config()
+            assert cfg["DATABASE_VENDOR"] == "postgresql"  # settings win
+            assert cfg["DISABLED_RULES"] == ["SM006"]  # pyproject-only key kept
+
+    def test_get_database_vendor(self):
+        """get_database_vendor reads DATABASE_VENDOR, None when unset."""
+        from django.test import override_settings
+
+        from django_safe_migrations.conf import get_database_vendor
+
+        with override_settings(SAFE_MIGRATIONS={"DATABASE_VENDOR": "mysql"}):
+            assert get_database_vendor() == "mysql"
+        with override_settings(SAFE_MIGRATIONS={}):
+            assert get_database_vendor() is None
+
+    def test_get_warnings_as_errors(self):
+        """get_warnings_as_errors reads the WARNINGS_AS_ERRORS list."""
+        from django.test import override_settings
+
+        from django_safe_migrations.conf import get_warnings_as_errors
+
+        with override_settings(SAFE_MIGRATIONS={"WARNINGS_AS_ERRORS": ["SM002"]}):
+            assert get_warnings_as_errors() == ["SM002"]
+        with override_settings(SAFE_MIGRATIONS={}):
+            assert get_warnings_as_errors() == []


### PR DESCRIPTION
v0.7.0 DX/config features (tasks #7-9).

- **pyproject.toml config**: `[tool.django_safe_migrations]` read as an alternative to the `SAFE_MIGRATIONS` setting (settings win). Useful for CLI / pre-commit. Python 3.11+ tomllib or `tomli`.
- **`--database-vendor` / `DATABASE_VENDOR`**: override the auto-detected vendor — develop on SQLite, lint for PostgreSQL (activates the 13 PostgreSQL-only rules). Threaded into the analyzer in both the command and CLI.
- **`--warnings-as-errors` / `WARNINGS_AS_ERRORS`**: promote specific WARNING rules to exit-1 failures (more granular than `--fail-on-warning`).

8 new tests (conf parsing/precedence + command integration); CHANGELOG. 771 tests pass; pre-commit green. (Full configuration.md treatment lands in the docs-sync task before release.)