### PR TITLE
feat: v0.7.0 enforcement — BLOCK_UNSAFE system check + lint-on-makemigrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database vendor so you can develop on SQLite but lint for PostgreSQL.
 - **`--warnings-as-errors` / `WARNINGS_AS_ERRORS`.** Promote specific
   warning-level rules to build failures (more granular than `--fail-on-warning`).
+- **Migrate-blocking system check (`BLOCK_UNSAFE`).** When enabled, an opt-in
+  Django system check reports ERROR-level migration issues, so `migrate` (and
+  other commands) refuse to run while unsafe migrations exist. Disabled by
+  default and guarded so it never crashes a command.
+- **Lint on `makemigrations`.** Installing the app makes `makemigrations`
+  analyse newly generated migrations and warn about safety issues. It is
+  warn-only by default (`--lint-strict` to fail, `--no-lint` to skip) and can
+  never break `makemigrations` itself.
 - **SM037** `direct_model_import_in_runpython` (INFO): a RunPython function that
   imports a model directly instead of using `apps.get_model()` breaks on a
   fresh database.

--- a/django_safe_migrations/apps.py
+++ b/django_safe_migrations/apps.py
@@ -11,5 +11,9 @@ class DjangoSafeMigrationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self) -> None:
-        """Perform initialization when the app is ready."""
-        pass
+        """Register the (opt-in) migration-safety system check."""
+        from django.core.checks import register
+
+        from django_safe_migrations.checks import check_migration_safety
+
+        register(check_migration_safety, "migrations")

--- a/django_safe_migrations/checks.py
+++ b/django_safe_migrations/checks.py
@@ -1,0 +1,51 @@
+"""Django system check that can block unsafe migrations.
+
+When ``SAFE_MIGRATIONS["BLOCK_UNSAFE"]`` is True, this check reports each
+ERROR-level migration issue as a Django ``Error``, which makes commands like
+``migrate`` refuse to run while unsafe migrations exist. It is disabled by
+default so it never slows normal commands.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.checks import CheckMessage
+from django.core.checks import Error as CheckError
+
+
+def check_migration_safety(
+    app_configs: Any = None, **kwargs: Any
+) -> list[CheckMessage]:
+    """System check that blocks migrate when unsafe migrations exist.
+
+    Returns an empty list unless ``SAFE_MIGRATIONS["BLOCK_UNSAFE"]`` is True.
+    """
+    from django_safe_migrations.conf import get_block_unsafe
+
+    if not get_block_unsafe():
+        return []
+
+    # Import lazily so importing this module never pulls in the analyzer.
+    from django_safe_migrations.analyzer import MigrationAnalyzer
+    from django_safe_migrations.rules.base import Severity
+
+    try:
+        analyzer = MigrationAnalyzer()
+        issues = analyzer.analyze_all()
+    except Exception:  # noqa: BLE001 - never let the check itself crash commands
+        return []
+
+    messages: list[CheckMessage] = []
+    for issue in issues:
+        if issue.severity is not Severity.ERROR:
+            continue
+        messages.append(
+            CheckError(
+                f"Unsafe migration ({issue.rule_id}): {issue.message}",
+                hint=issue.suggestion,
+                obj=f"{issue.app_label}.{issue.migration_name}",
+                id=f"safe_migrations.{issue.rule_id}",
+            )
+        )
+    return messages

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -186,6 +186,7 @@ DEFAULTS: dict[str, Any] = {
     "EXTRA_RULES": [],  # Custom rule class paths to load
     "DATABASE_VENDOR": None,  # Override auto-detected DB vendor
     "WARNINGS_AS_ERRORS": [],  # Rule IDs whose warnings fail the build
+    "BLOCK_UNSAFE": False,  # Block migrate via system check on ERROR issues
 }
 
 
@@ -246,6 +247,11 @@ def get_warnings_as_errors() -> list[str]:
     """Get the list of rule IDs whose warnings should fail the build."""
     value = get_config().get("WARNINGS_AS_ERRORS", [])
     return list(value) if value else []
+
+
+def get_block_unsafe() -> bool:
+    """Get whether a system check should block migrate on ERROR-level issues."""
+    return bool(get_config().get("BLOCK_UNSAFE", False))
 
 
 def get_disabled_rules() -> list[str]:

--- a/django_safe_migrations/management/commands/makemigrations.py
+++ b/django_safe_migrations/management/commands/makemigrations.py
@@ -1,0 +1,78 @@
+"""``makemigrations`` wrapper that lints newly generated migrations.
+
+Subclasses Django's ``makemigrations`` so that, after migrations are created,
+they are analysed for safety issues. By default it only *warns* (it never
+blocks creating a migration); pass ``--lint-strict`` to exit non-zero when the
+new migrations contain ERROR-level issues. Use ``--no-lint`` to skip linting.
+
+The linting is wrapped so it can never break ``makemigrations`` itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from django.core.management.commands.makemigrations import Command as BaseCommand
+
+
+class Command(BaseCommand):
+    """``makemigrations`` with a post-generation safety lint."""
+
+    def add_arguments(self, parser: Any) -> None:
+        """Add the lint-control arguments on top of makemigrations'."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--no-lint",
+            action="store_true",
+            help="Skip safe-migrations linting after generating migrations",
+        )
+        parser.add_argument(
+            "--lint-strict",
+            action="store_true",
+            help="Exit non-zero if newly created migrations have ERROR issues",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """Generate migrations, then lint them (warn-only by default)."""
+        super().handle(*args, **options)
+
+        if (
+            options.get("no_lint")
+            or options.get("dry_run")
+            or options.get("check_changes")
+        ):
+            return
+
+        self._lint_migrations(strict=bool(options.get("lint_strict")))
+
+    def _lint_migrations(self, strict: bool) -> None:
+        """Analyse migrations and report issues; optionally exit non-zero."""
+        try:
+            from django_safe_migrations.analyzer import MigrationAnalyzer
+            from django_safe_migrations.rules.base import Severity
+
+            analyzer = MigrationAnalyzer()
+            try:
+                issues = analyzer.analyze_new_migrations()
+            except Exception:  # noqa: BLE001 - no DB / unapplied lookup failed
+                issues = analyzer.analyze_all()
+        except Exception:  # noqa: BLE001 - never let linting break makemigrations
+            return
+
+        if not issues:
+            return
+
+        self.stdout.write(self.style.WARNING("\nMigration safety issues detected:"))
+        for issue in issues:
+            self.stdout.write(f"  {issue}")
+
+        errors = [i for i in issues if i.severity is Severity.ERROR]
+        if errors and strict:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"\n{len(errors)} unsafe migration issue(s). "
+                    "Fix them, or re-run without --lint-strict."
+                )
+            )
+            sys.exit(1)

--- a/tests/unit/test_makemigrations.py
+++ b/tests/unit/test_makemigrations.py
@@ -1,0 +1,77 @@
+"""Tests for the lint-on-makemigrations command wrapper."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from django_safe_migrations.management.commands.makemigrations import Command
+from django_safe_migrations.rules.base import Issue, Severity
+
+_ERROR = Issue(
+    rule_id="SM001",
+    severity=Severity.ERROR,
+    operation="op",
+    message="bad",
+    app_label="a",
+    migration_name="0002",
+)
+
+
+class TestLintOnMakemigrations:
+    """Tests for the post-generation lint."""
+
+    def test_warns_on_issues(self):
+        """Detected issues are printed (warn-only by default)."""
+        buf = StringIO()
+        cmd = Command(stdout=buf)
+        with patch(
+            "django_safe_migrations.analyzer."
+            "MigrationAnalyzer.analyze_new_migrations",
+            return_value=[_ERROR],
+        ):
+            cmd._lint_migrations(strict=False)
+        assert "SM001" in buf.getvalue()
+
+    def test_strict_exits_on_errors(self):
+        """--lint-strict exits non-zero when there are ERROR-level issues."""
+        cmd = Command(stdout=StringIO(), stderr=StringIO())
+        with patch(
+            "django_safe_migrations.analyzer."
+            "MigrationAnalyzer.analyze_new_migrations",
+            return_value=[_ERROR],
+        ):
+            with pytest.raises(SystemExit):
+                cmd._lint_migrations(strict=True)
+
+    def test_no_issues_does_not_exit(self):
+        """No issues means no output and no exit, even in strict mode."""
+        buf = StringIO()
+        cmd = Command(stdout=buf)
+        with patch(
+            "django_safe_migrations.analyzer."
+            "MigrationAnalyzer.analyze_new_migrations",
+            return_value=[],
+        ):
+            cmd._lint_migrations(strict=True)
+        assert buf.getvalue() == ""
+
+    def test_falls_back_to_analyze_all_without_db(self):
+        """If analyze_new_migrations fails (no DB), it falls back to analyze_all."""
+        buf = StringIO()
+        cmd = Command(stdout=buf)
+        with (
+            patch(
+                "django_safe_migrations.analyzer."
+                "MigrationAnalyzer.analyze_new_migrations",
+                side_effect=RuntimeError("no db"),
+            ),
+            patch(
+                "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+                return_value=[_ERROR],
+            ),
+        ):
+            cmd._lint_migrations(strict=False)
+        assert "SM001" in buf.getvalue()

--- a/tests/unit/test_system_check.py
+++ b/tests/unit/test_system_check.py
@@ -1,0 +1,53 @@
+"""Tests for the migrate-blocking system check (BLOCK_UNSAFE)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from django_safe_migrations.checks import check_migration_safety
+from django_safe_migrations.rules.base import Issue, Severity
+
+_ERROR = Issue(
+    rule_id="SM001",
+    severity=Severity.ERROR,
+    operation="op",
+    message="bad",
+    app_label="a",
+    migration_name="0002",
+)
+_WARNING = Issue(
+    rule_id="SM002", severity=Severity.WARNING, operation="op", message="meh"
+)
+
+
+class TestMigrationSafetyCheck:
+    """Tests for check_migration_safety."""
+
+    def test_disabled_by_default(self):
+        """With BLOCK_UNSAFE unset, the check returns nothing (and is cheap)."""
+        with override_settings(SAFE_MIGRATIONS={}):
+            assert check_migration_safety() == []
+
+    def test_reports_only_errors_when_enabled(self):
+        """When enabled, only ERROR-level issues become check Errors."""
+        with override_settings(SAFE_MIGRATIONS={"BLOCK_UNSAFE": True}):
+            with patch(
+                "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+                return_value=[_ERROR, _WARNING],
+            ):
+                messages = check_migration_safety()
+
+        assert len(messages) == 1
+        assert messages[0].id == "safe_migrations.SM001"
+        assert messages[0].is_serious()
+
+    def test_never_crashes_on_analyzer_error(self):
+        """The check must never break the command that triggered it."""
+        with override_settings(SAFE_MIGRATIONS={"BLOCK_UNSAFE": True}):
+            with patch(
+                "django_safe_migrations.analyzer.MigrationAnalyzer.analyze_all",
+                side_effect=RuntimeError("boom"),
+            ):
+                assert check_migration_safety() == []


### PR DESCRIPTION
v0.7.0 enforcement features (tasks #10, #11).

- **Migrate-blocking system check** (`BLOCK_UNSAFE`): an opt-in Django system check (registered in `apps.ready`) reports ERROR-level migration issues, so `migrate` (and other commands) refuse to run while unsafe migrations exist. **Disabled by default**, cheap when off, and guarded so it can never crash a command.
- **Lint on `makemigrations`**: subclasses Django's `makemigrations` to analyse newly generated migrations. **Warn-only by default** (`--lint-strict` to fail, `--no-lint` to skip); wrapped so it never breaks `makemigrations`, and falls back to `analyze_all` when no DB is reachable.

7 new tests; CHANGELOG. 778 tests pass; pre-commit green.