### PR TITLE
feat: v0.7.0 SM042 alter_composite_primary_key (+ decision-rule outcomes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SM054** `multiple_heavy_ops_same_table` (INFO): three or more heavy schema
   operations on the same table in one migration hold the lock for their
   combined duration.
+- **SM042** `alter_composite_primary_key` (ERROR, Django 5.2+): Django cannot
+  migrate a table to/from a `CompositePrimaryKey` after creation — the
+  generated migration fails at `migrate` time.
 - **SM047** `constraint_missing_not_valid` (WARNING, PostgreSQL): RunSQL that
   adds a CHECK/FOREIGN KEY constraint without `NOT VALID` scans the whole table
   under an ACCESS EXCLUSIVE lock.

--- a/README.md
+++ b/README.md
@@ -27,54 +27,55 @@ Django Safe Migrations analyzes your Django migrations and warns you about opera
 
 ## Rules
 
-| Rule ID | Name                               | Severity | Description                                                     |
-| ------- | ---------------------------------- | -------- | --------------------------------------------------------------- |
-| SM001   | `not_null_without_default`         | ERROR    | Adding NOT NULL column without default will lock table          |
-| SM002   | `drop_column_unsafe`               | WARNING  | Dropping column while old code may reference it                 |
-| SM003   | `drop_table_unsafe`                | WARNING  | Dropping table while old code may reference it                  |
-| SM004   | `alter_column_type`                | WARNING  | Changing column type may rewrite table                          |
-| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks) (PostgreSQL)      |
-| SM006   | `rename_column`                    | INFO     | Column rename may break old code during deployment              |
-| SM007   | `run_sql_unsafe`                   | WARNING  | RunSQL without reverse_sql is not reversible                    |
-| SM008   | `large_data_migration`             | INFO     | Data migration may be slow on large tables                      |
-| SM009   | `add_unique_constraint`            | ERROR    | Adding unique constraint requires full table scan               |
-| SM010   | `index_not_concurrent`             | ERROR    | Index creation without CONCURRENTLY (PostgreSQL)                |
-| SM011   | `unique_constraint_not_concurrent` | ERROR    | Unique constraint without concurrent index                      |
-| SM012   | `enum_add_value_transaction`       | ERROR    | Adding enum value inside transaction (PostgreSQL)               |
-| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table (PostgreSQL)           |
-| SM014   | `rename_model`                     | WARNING  | Model rename may break FKs and external references              |
-| SM015   | `alter_unique_together`            | WARNING  | Deprecated in favor of UniqueConstraint                         |
-| SM016   | `run_python_no_reverse`            | INFO     | RunPython without reverse_code is not reversible                |
-| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows (PostgreSQL)       |
-| SM018   | `concurrent_in_atomic_migration`   | ERROR    | Concurrent index operations require atomic=False                |
-| SM019   | `reserved_keyword_column`          | INFO     | Column name is a reserved SQL keyword                           |
-| SM020   | `alter_field_null_false`           | ERROR    | AlterField null=False without data backfill                     |
-| SM021   | `alter_field_unique`               | ERROR    | Adding UNIQUE via AlterField on existing data                   |
-| SM022   | `expensive_default_callable`       | WARNING  | Default value uses expensive callable (e.g., now())             |
-| SM023   | `add_many_to_many`                 | INFO     | ManyToMany creates junction table (potential locks)             |
-| SM024   | `sql_injection_pattern`            | ERROR    | SQL injection patterns detected in RunSQL                       |
-| SM025   | `fk_without_index`                 | WARNING  | Foreign key without db_index on large tables                    |
-| SM026   | `run_python_no_batching`           | WARNING  | RunPython using .all() without batching                         |
-| SM027   | `missing_merge_migration`          | ERROR    | Multiple leaf migrations need merge migration                   |
-| SM028   | `prefer_bigint_over_int`           | WARNING  | Prefer BigAutoField over 32-bit AutoField primary keys          |
-| SM029   | `drop_not_null`                    | WARNING  | Dropping NOT NULL constraint may allow unintended NULLs         |
-| SM030   | `require_concurrent_index_delete`  | ERROR    | Index removal without CONCURRENTLY locks table (PostgreSQL)     |
-| SM031   | `prefer_text_over_varchar`         | INFO     | Consider TextField over CharField on PostgreSQL                 |
-| SM032   | `prefer_timestamptz`               | INFO     | DateTimeField without USE_TZ stores naive datetimes             |
-| SM033   | `adding_field_with_default`        | WARNING  | NOT NULL field with Python default rewrites all rows            |
-| SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)          |
-| SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                           |
-| SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                        |
-| SM037   | `direct_model_import_in_runpython` | INFO     | RunPython imports a model directly instead of apps.get_model()  |
-| SM038   | `mixed_schema_and_data_operations` | WARNING  | Migration mixes schema changes with data operations             |
-| SM040   | `volatile_default_with_unique`     | ERROR    | Unique field with a callable default fails on populated tables  |
-| SM041   | `adding_stored_generated_field`    | WARNING  | Adding a stored GeneratedField rewrites the table (Django 5.0+) |
-| SM047   | `constraint_missing_not_valid`     | WARNING  | RunSQL ADD CONSTRAINT (CHECK/FK) without NOT VALID (PostgreSQL) |
-| SM048   | `truncate_in_runsql`               | WARNING  | TRUNCATE in a migration deletes all table data                  |
-| SM049   | `transaction_nesting_in_runsql`    | ERROR    | Explicit BEGIN/COMMIT/ROLLBACK in RunSQL in an atomic migration |
-| SM050   | `drop_database_in_runsql`          | ERROR    | DROP DATABASE/SCHEMA in a migration is catastrophic             |
-| SM054   | `multiple_heavy_ops_same_table`    | INFO     | 3+ heavy schema operations on one table in a migration          |
-| SM056   | `adding_exclusion_constraint`      | WARNING  | Exclusion constraint scans the whole table (PostgreSQL)         |
+| Rule ID | Name                               | Severity | Description                                                          |
+| ------- | ---------------------------------- | -------- | -------------------------------------------------------------------- |
+| SM001   | `not_null_without_default`         | ERROR    | Adding NOT NULL column without default will lock table               |
+| SM002   | `drop_column_unsafe`               | WARNING  | Dropping column while old code may reference it                      |
+| SM003   | `drop_table_unsafe`                | WARNING  | Dropping table while old code may reference it                       |
+| SM004   | `alter_column_type`                | WARNING  | Changing column type may rewrite table                               |
+| SM005   | `add_foreign_key_validates`        | WARNING  | FK constraint validates existing rows (locks) (PostgreSQL)           |
+| SM006   | `rename_column`                    | INFO     | Column rename may break old code during deployment                   |
+| SM007   | `run_sql_unsafe`                   | WARNING  | RunSQL without reverse_sql is not reversible                         |
+| SM008   | `large_data_migration`             | INFO     | Data migration may be slow on large tables                           |
+| SM009   | `add_unique_constraint`            | ERROR    | Adding unique constraint requires full table scan                    |
+| SM010   | `index_not_concurrent`             | ERROR    | Index creation without CONCURRENTLY (PostgreSQL)                     |
+| SM011   | `unique_constraint_not_concurrent` | ERROR    | Unique constraint without concurrent index                           |
+| SM012   | `enum_add_value_transaction`       | ERROR    | Adding enum value inside transaction (PostgreSQL)                    |
+| SM013   | `alter_varchar_length`             | WARNING  | Decreasing VARCHAR length rewrites table (PostgreSQL)                |
+| SM014   | `rename_model`                     | WARNING  | Model rename may break FKs and external references                   |
+| SM015   | `alter_unique_together`            | WARNING  | Deprecated in favor of UniqueConstraint                              |
+| SM016   | `run_python_no_reverse`            | INFO     | RunPython without reverse_code is not reversible                     |
+| SM017   | `add_check_constraint`             | WARNING  | Check constraint validates all existing rows (PostgreSQL)            |
+| SM018   | `concurrent_in_atomic_migration`   | ERROR    | Concurrent index operations require atomic=False                     |
+| SM019   | `reserved_keyword_column`          | INFO     | Column name is a reserved SQL keyword                                |
+| SM020   | `alter_field_null_false`           | ERROR    | AlterField null=False without data backfill                          |
+| SM021   | `alter_field_unique`               | ERROR    | Adding UNIQUE via AlterField on existing data                        |
+| SM022   | `expensive_default_callable`       | WARNING  | Default value uses expensive callable (e.g., now())                  |
+| SM023   | `add_many_to_many`                 | INFO     | ManyToMany creates junction table (potential locks)                  |
+| SM024   | `sql_injection_pattern`            | ERROR    | SQL injection patterns detected in RunSQL                            |
+| SM025   | `fk_without_index`                 | WARNING  | Foreign key without db_index on large tables                         |
+| SM026   | `run_python_no_batching`           | WARNING  | RunPython using .all() without batching                              |
+| SM027   | `missing_merge_migration`          | ERROR    | Multiple leaf migrations need merge migration                        |
+| SM028   | `prefer_bigint_over_int`           | WARNING  | Prefer BigAutoField over 32-bit AutoField primary keys               |
+| SM029   | `drop_not_null`                    | WARNING  | Dropping NOT NULL constraint may allow unintended NULLs              |
+| SM030   | `require_concurrent_index_delete`  | ERROR    | Index removal without CONCURRENTLY locks table (PostgreSQL)          |
+| SM031   | `prefer_text_over_varchar`         | INFO     | Consider TextField over CharField on PostgreSQL                      |
+| SM032   | `prefer_timestamptz`               | INFO     | DateTimeField without USE_TZ stores naive datetimes                  |
+| SM033   | `adding_field_with_default`        | WARNING  | NOT NULL field with Python default rewrites all rows                 |
+| SM034   | `prefer_identity`                  | INFO     | Consider IDENTITY columns on PostgreSQL (Django < 4.0)               |
+| SM035   | `require_lock_timeout`             | INFO     | DDL in RunSQL should set lock_timeout                                |
+| SM036   | `prefer_if_exists`                 | INFO     | Use IF [NOT] EXISTS in CREATE/DROP TABLE                             |
+| SM037   | `direct_model_import_in_runpython` | INFO     | RunPython imports a model directly instead of apps.get_model()       |
+| SM038   | `mixed_schema_and_data_operations` | WARNING  | Migration mixes schema changes with data operations                  |
+| SM040   | `volatile_default_with_unique`     | ERROR    | Unique field with a callable default fails on populated tables       |
+| SM041   | `adding_stored_generated_field`    | WARNING  | Adding a stored GeneratedField rewrites the table (Django 5.0+)      |
+| SM042   | `alter_composite_primary_key`      | ERROR    | Migrating to/from a CompositePrimaryKey is unsupported (Django 5.2+) |
+| SM047   | `constraint_missing_not_valid`     | WARNING  | RunSQL ADD CONSTRAINT (CHECK/FK) without NOT VALID (PostgreSQL)      |
+| SM048   | `truncate_in_runsql`               | WARNING  | TRUNCATE in a migration deletes all table data                       |
+| SM049   | `transaction_nesting_in_runsql`    | ERROR    | Explicit BEGIN/COMMIT/ROLLBACK in RunSQL in an atomic migration      |
+| SM050   | `drop_database_in_runsql`          | ERROR    | DROP DATABASE/SCHEMA in a migration is catastrophic                  |
+| SM054   | `multiple_heavy_ops_same_table`    | INFO     | 3+ heavy schema operations on one table in a migration               |
+| SM056   | `adding_exclusion_constraint`      | WARNING  | Exclusion constraint scans the whole table (PostgreSQL)              |
 
 ## Installation
 

--- a/django_safe_migrations/conf.py
+++ b/django_safe_migrations/conf.py
@@ -130,6 +130,7 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM027",
         "SM030",
         "SM040",
+        "SM042",
         "SM049",
         "SM050",
     ],
@@ -163,6 +164,7 @@ RULE_CATEGORIES: dict[str, list[str]] = {
         "SM033",
         "SM038",
         "SM041",
+        "SM042",
     ],
     "performance": ["SM022", "SM025", "SM026", "SM028", "SM033", "SM041", "SM054"],
 }

--- a/django_safe_migrations/rules/__init__.py
+++ b/django_safe_migrations/rules/__init__.py
@@ -24,6 +24,7 @@ from django_safe_migrations.rules.add_index import (
 from django_safe_migrations.rules.alter_field import (
     AddForeignKeyValidatesRule,
     AlterColumnTypeRule,
+    AlterCompositePrimaryKeyRule,
     AlterFieldNullFalseRule,
     AlterFieldUniqueRule,
     AlterVarcharLengthRule,
@@ -128,6 +129,7 @@ __all__ = [
     "DirectModelImportInRunPythonRule",
     "MixedSchemaAndDataRule",
     "MultipleHeavyOpsSameTableRule",
+    "AlterCompositePrimaryKeyRule",
     # Functions
     "get_all_rules",
     "get_rules_for_db",
@@ -193,6 +195,7 @@ ALL_RULES: list[type[BaseRule]] = [
     DirectModelImportInRunPythonRule,  # SM037
     MixedSchemaAndDataRule,  # SM038
     MultipleHeavyOpsSameTableRule,  # SM054
+    AlterCompositePrimaryKeyRule,  # SM042
 ]
 
 logger = logging.getLogger("django_safe_migrations")

--- a/django_safe_migrations/rules/alter_field.py
+++ b/django_safe_migrations/rules/alter_field.py
@@ -982,3 +982,46 @@ class DropNotNullRule(BaseRule):
        ...
    )
 """
+
+
+class AlterCompositePrimaryKeyRule(BaseRule):
+    """Detect migrating an existing model to a CompositePrimaryKey.
+
+    Django 5.2 added ``CompositePrimaryKey``, but it does not support migrating
+    a table *to* (or *from*) a composite primary key after the table has been
+    created. ``makemigrations`` will happily generate an ``AlterField`` /
+    ``AddField`` for it, but ``migrate`` then fails. A composite primary key
+    must be defined when the model is first created.
+    """
+
+    rule_id = "SM042"
+    severity = Severity.ERROR
+    description = "Migrating to a CompositePrimaryKey after table creation fails"
+    django_min_version = (5, 2)
+
+    def check(
+        self,
+        operation: Operation,
+        migration: Migration,
+        **kwargs: object,
+    ) -> Optional[Issue]:
+        """Flag an AddField/AlterField whose field is a CompositePrimaryKey."""
+        if not isinstance(operation, (migrations.AddField, migrations.AlterField)):
+            return None
+
+        field = getattr(operation, "field", None)
+        # Match by class name so the rule needs no Django 5.2-only import.
+        if field is not None and type(field).__name__ == "CompositePrimaryKey":
+            return self.create_issue(
+                operation=operation,
+                migration=migration,
+                message=(
+                    f"Operation sets a CompositePrimaryKey on existing model "
+                    f"'{getattr(operation, 'model_name', '?')}'. Django does not "
+                    "support migrating to or from a composite primary key after "
+                    "the table is created — this will fail at migrate time. "
+                    "Define the composite primary key when the model is first "
+                    "created (or recreate the table via SeparateDatabaseAndState)."
+                ),
+            )
+        return None

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ ERROR [SM001] myapp/migrations/0002_add_email.py:15
 
 ## Features
 
-- **46 built-in rules** covering schema changes, locking, data loss, and best practices
+- **47 built-in rules** covering schema changes, locking, data loss, and best practices
 - **Database-aware** rules, including PostgreSQL-specific checks for concurrent indexes, TEXT vs VARCHAR, and IDENTITY columns, plus MySQL- and SQLite-specific categories
 - **Fix suggestions** with safe migration patterns for every issue
 - **CI/CD ready** — GitHub Actions, GitLab Code Quality, JSON, SARIF output

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1963,3 +1963,31 @@ in one migration.
 The table lock is held for the combined duration of all the operations.
 Splitting them into separate migrations shortens each lock window and reduces
 deadlock risk.
+
+______________________________________________________________________
+
+## SM042: alter_composite_primary_key
+
+| Field         | Value |
+| ------------- | ----- |
+| **Rule ID**   | SM042 |
+| **Severity**  | ERROR |
+| **Databases** | All   |
+| **Django**    | 5.2+  |
+
+### What it detects
+
+An `AddField` or `AlterField` whose field is a `CompositePrimaryKey` on an
+existing model.
+
+### Why it matters
+
+Django 5.2 supports `CompositePrimaryKey`, but it does **not** support migrating
+a table to (or from) a composite primary key after the table is created.
+`makemigrations` will generate the operation, but `migrate` will fail.
+
+### Safe pattern
+
+Define the composite primary key when the model is first created. To change an
+existing table, recreate it (e.g. via `SeparateDatabaseAndState` plus raw SQL)
+during a planned migration.

--- a/tests/unit/rules/test_alter_field_rules.py
+++ b/tests/unit/rules/test_alter_field_rules.py
@@ -888,3 +888,46 @@ class TestSmartColumnTypeChanges:
         )
         assert issue is not None
         assert issue.rule_id == "SM004"
+
+
+class TestAlterCompositePrimaryKeyRule:
+    """Tests for AlterCompositePrimaryKeyRule (SM042)."""
+
+    def test_flags_alter_to_composite_pk(self, mock_migration):
+        """An AlterField to a CompositePrimaryKey is flagged."""
+        from django_safe_migrations.rules.alter_field import (
+            AlterCompositePrimaryKeyRule,
+        )
+
+        # Stand-in matching the class name the rule checks (version-independent).
+        class CompositePrimaryKey:
+            pass
+
+        rule = AlterCompositePrimaryKeyRule()
+        op = migrations.AlterField(
+            model_name="order", name="pk", field=CompositePrimaryKey()
+        )
+        issue = rule.check(op, mock_migration)
+        assert issue is not None
+        assert issue.rule_id == "SM042"
+        assert issue.severity == Severity.ERROR
+
+    def test_ignores_normal_alter_field(self, mock_migration):
+        """A normal AlterField is not flagged."""
+        from django_safe_migrations.rules.alter_field import (
+            AlterCompositePrimaryKeyRule,
+        )
+
+        rule = AlterCompositePrimaryKeyRule()
+        op = migrations.AlterField(
+            model_name="order", name="total", field=models.IntegerField()
+        )
+        assert rule.check(op, mock_migration) is None
+
+    def test_requires_django_5_2(self):
+        """SM042 declares a Django 5.2 minimum."""
+        from django_safe_migrations.rules.alter_field import (
+            AlterCompositePrimaryKeyRule,
+        )
+
+        assert AlterCompositePrimaryKeyRule().django_min_version == (5, 2)

--- a/tests/unit/rules/test_extra_rules.py
+++ b/tests/unit/rules/test_extra_rules.py
@@ -224,8 +224,8 @@ class TestAllRulesRegistry:
 
     def test_all_rules_contains_expected_count(self):
         """Test ALL_RULES contains expected number of rules."""
-        # SM001-SM036 plus v0.7.0 rules SM037/038/040/041/047-050/054/056.
-        assert len(ALL_RULES) == 46
+        # SM001-SM036 plus v0.7.0 rules SM037/038/040-042/047-050/054/056.
+        assert len(ALL_RULES) == 47
 
     def test_all_rules_have_unique_ids(self):
         """Test all rules have unique IDs."""


### PR DESCRIPTION
Decision rules (task #6), per docs/roadmap/v0.7.0.md.

**Ships SM042** `alter_composite_primary_key` (ERROR, Django 5.2+): an AddField/AlterField that sets a `CompositePrimaryKey` on an existing model. Django does not support migrating a table to/from a composite PK after creation — the migration fails at `migrate` time. Detected by class name (no 5.2-only import) and gated by `django_min_version=(5,2)`. The supported path (defining it in a new `CreateModel`) does not trigger it, so FP risk is low.

**Intentionally NOT shipped** (FP/overlap, per the design review): SM039 (overlaps SM002/SM003), SM045 (contradicts our own SM022/SM033 advice), SM051 (overlaps SM033), SM055 (high FP). Documented in the roadmap.

**47 rules total.** 3 version-independent tests; README/rules.md/index/CHANGELOG. 781 tests pass; pre-commit green.