### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-04
+
 ### Added
 
 - **Django-version gating for rules.** Rules may declare a

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.6.3"
+version = "0.7.0"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## v0.7.0

Bumps `pyproject.toml` + `__init__.py` to **0.7.0** and dates the CHANGELOG section. Merging then tagging `v0.7.0` triggers `publish.yml` (test + version-match + twine gates) → PyPI + GitHub release.

### Rules (47 total — 11 new + SM057 enhancement)
| Rule | Name | Severity | Notes |
|------|------|----------|-------|
| SM037 | direct_model_import_in_runpython | INFO | heuristic source scan |
| SM038 | mixed_schema_and_data_operations | WARNING | migration-level |
| SM040 | volatile_default_with_unique | ERROR | |
| SM041 | adding_stored_generated_field | WARNING | Django 5.0+ |
| SM042 | alter_composite_primary_key | ERROR | Django 5.2+ |
| SM047 | constraint_missing_not_valid | WARNING | PostgreSQL |
| SM048 | truncate_in_runsql | WARNING | |
| SM049 | transaction_nesting_in_runsql | ERROR | gated on `migration.atomic` |
| SM050 | drop_database_in_runsql | ERROR | |
| SM054 | multiple_heavy_ops_same_table | INFO | migration-level |
| SM056 | adding_exclusion_constraint | WARNING | PostgreSQL |
| SM057 | smart_column_type_changes | — | SM004 allowlist (warn→safe only) |

### Features
- `pyproject.toml` config (`[tool.django_safe_migrations]`; settings win)
- `--database-vendor` / `DATABASE_VENDOR` override
- selective `--warnings-as-errors` / `WARNINGS_AS_ERRORS`
- lint-on-`makemigrations` (warn-only; `--lint-strict`/`--no-lint`)
- migrate-blocking system check (`BLOCK_UNSAFE`, opt-in)
- Phase-0 infra: Django-version gating + migration-level rule hook

### Not shipped (documented in roadmap)
SM039/045/051/055 (FP/overlap); SM043/044/046/052/053 dropped (redundant/infeasible). Medium DX features (`--since-commit`, caching, `--check-reverse`, `--classify-phase`, GitHub-PR reporter) trail into v0.7.x.

### Verification
781 passed, 19 skipped · pre-commit green · version matches in both files (guarded by `test_version.py`). Docs synced per-batch (README table, `docs/rules.md`, `docs/index.md` count, `docs/configuration.md` categories + settings).