### PR TITLE
feat: --since-commit (committed-range migration checks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--since-commit COMMIT`.** Check only migrations changed in the committed
+  range `COMMIT..HEAD`. Unlike `--diff` (which compares against the working
+  tree), uncommitted edits are ignored — suited to incremental CI that lints
+  only what was committed since the last green build. Mutually exclusive with
+  `--diff`.
+
 ## [0.7.0] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ python manage.py check_migrations --format=gitlab
 python manage.py check_migrations --diff
 python manage.py check_migrations --diff main
 
+# Incremental - only migrations committed since a known-good commit
+python manage.py check_migrations --since-commit origin/main
+
 # Baseline - suppress existing issues
 python manage.py check_migrations --generate-baseline .migration-baseline.json
 python manage.py check_migrations --baseline .migration-baseline.json
@@ -230,6 +233,7 @@ repos:
 | `--exclude-apps`           | Apps to exclude from checking                                 |
 | `--include-django-apps`    | Include Django's built-in apps                                |
 | `--diff [BASE_REF]`        | Only check migrations changed since BASE_REF (default: main)  |
+| `--since-commit COMMIT`    | Only check migrations committed in COMMIT..HEAD (no worktree) |
 | `--baseline FILE`          | Exclude issues present in baseline file                       |
 | `--generate-baseline FILE` | Generate baseline file from current issues                    |
 | `--interactive`            | Interactively review each issue                               |

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -203,6 +203,16 @@ Documentation: https://django-safe-migrations.readthedocs.io/
         help="Only check migrations changed since BASE_REF (default: main)",
     )
     parser.add_argument(
+        "--since-commit",
+        type=str,
+        default=None,
+        metavar="COMMIT",
+        help=(
+            "Only check migrations committed in COMMIT..HEAD "
+            "(committed changes only; ignores the working tree)"
+        ),
+    )
+    parser.add_argument(
         "--baseline",
         type=str,
         default=None,
@@ -300,21 +310,31 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     # Collect issues
     issues: list[Issue] = []
 
-    if args.diff is not None:
+    if args.diff is not None and args.since_commit is not None:
+        print("Use only one of --diff and --since-commit.", file=sys.stderr)
+        return 2
+
+    if args.diff is not None or args.since_commit is not None:
         # Diff mode — only check changed migrations
         from django_safe_migrations.diff import (
             DiffError,
             get_changed_apps_and_migrations,
+            get_committed_apps_and_migrations,
         )
 
         try:
-            changed = get_changed_apps_and_migrations(args.diff)
+            if args.since_commit is not None:
+                changed = get_committed_apps_and_migrations(args.since_commit)
+                mode_desc = f"committed since {args.since_commit}"
+            else:
+                changed = get_changed_apps_and_migrations(args.diff)
+                mode_desc = f"changed vs {args.diff}"
         except DiffError as e:
             print(str(e), file=sys.stderr)
             return 2
         if args.verbose:
             print(
-                f"Diff mode: checking {len(changed)} changed migration(s)",
+                f"Diff mode ({mode_desc}): checking {len(changed)} migration(s)",
                 file=sys.stderr,
             )
         for app_label, migration_name in changed:

--- a/django_safe_migrations/diff.py
+++ b/django_safe_migrations/diff.py
@@ -27,36 +27,40 @@ class DiffError(Exception):
     pass
 
 
-def get_changed_migration_files(base_ref: str = "main") -> list[str]:
-    """Get migration files changed since *base_ref*.
+def _run_git_diff_names(diff_args: list[str]) -> list[str]:
+    """Run ``git diff --name-only`` with *diff_args* and return migration files.
 
-    Uses ``git diff --name-only`` to find Python files under any
-    ``migrations/`` directory that have been added or modified.
+    Shared plumbing for working-tree diffs (``--diff``) and committed-range
+    diffs (``--since-commit``). Filters the output to Python files under any
+    ``migrations/`` directory that still exist on disk.
 
     Args:
-        base_ref: Git ref to diff against (branch, tag, or commit).
+        diff_args: Extra arguments passed to ``git diff`` after the standard
+            ``--name-only --diff-filter=ACMR`` (e.g. ``["main"]`` or
+            ``["abc123..HEAD"]``).
 
     Returns:
         List of absolute paths to changed migration files.
 
     Raises:
-        DiffError: If the git ref does not exist or git command fails.
+        DiffError: If an arg looks like a git option, or git fails / is absent.
     """
-    # Reject refs that could be interpreted as git options (argument
-    # injection, e.g. ``--output=<file>`` which would make git write to an
-    # arbitrary path). A leading dash is never valid in a branch/tag/commit.
-    if base_ref.startswith("-"):
-        raise DiffError(f"Invalid base ref '{base_ref}': refs may not start with '-'.")
+    # Reject args that could be interpreted as git options (argument injection,
+    # e.g. ``--output=<file>`` which would make git write to an arbitrary path).
+    # A leading dash is never valid in a branch/tag/commit or a ``A..B`` range.
+    for arg in diff_args:
+        if arg.startswith("-"):
+            raise DiffError(f"Invalid git ref '{arg}': refs may not start with '-'.")
     try:
         result = subprocess.run(  # nosec B603 B607
-            ["git", "diff", "--name-only", "--diff-filter=ACMR", base_ref],
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", *diff_args],
             capture_output=True,
             text=True,
             check=True,
             cwd=_find_git_root(),
         )
     except subprocess.CalledProcessError as e:
-        msg = f"Could not run git diff against '{base_ref}': {e}"
+        msg = f"Could not run git diff ({' '.join(diff_args)}): {e}"
         if e.stderr:
             msg += f"\ngit stderr: {e.stderr.strip()}"
         logger.error(msg)
@@ -79,27 +83,68 @@ def get_changed_migration_files(base_ref: str = "main") -> list[str]:
             if os.path.exists(abs_path):
                 changed.append(abs_path)
 
+    return changed
+
+
+def get_changed_migration_files(base_ref: str = "main") -> list[str]:
+    """Get migration files changed since *base_ref* (vs the working tree).
+
+    Uses ``git diff --name-only`` to find Python files under any
+    ``migrations/`` directory that have been added or modified relative to
+    *base_ref*, including uncommitted working-tree changes.
+
+    Args:
+        base_ref: Git ref to diff against (branch, tag, or commit).
+
+    Returns:
+        List of absolute paths to changed migration files.
+
+    Raises:
+        DiffError: If the git ref does not exist or git command fails.
+    """
+    changed = _run_git_diff_names([base_ref])
     logger.debug("Found %d changed migration file(s) since %s", len(changed), base_ref)
     return changed
 
 
-def get_changed_apps_and_migrations(
-    base_ref: str = "main",
-) -> list[tuple[str, str]]:
-    """Get (app_label, migration_name) pairs for changed migrations.
+def get_committed_migration_files(since_commit: str) -> list[str]:
+    """Get migration files committed since *since_commit* (excludes working tree).
 
-    Parses the file paths to extract app labels and migration names.
-    The app label is resolved via Django's app registry so that apps
-    whose ``AppConfig.label`` differs from their package directory name
-    are handled correctly.
+    Unlike :func:`get_changed_migration_files`, this diffs the committed range
+    ``<since_commit>..HEAD`` so that uncommitted edits are ignored. This suits
+    incremental CI ("lint only what was committed since the last green build").
 
     Args:
-        base_ref: Git ref to diff against.
+        since_commit: Git commit/ref marking the lower bound (exclusive).
 
     Returns:
-        List of (app_label, migration_name) tuples.
+        List of absolute paths to migration files changed in the range.
+
+    Raises:
+        DiffError: If *since_commit* is empty/invalid or git command fails.
     """
-    files = get_changed_migration_files(base_ref)
+    if not since_commit or not since_commit.strip():
+        raise DiffError("--since-commit requires a non-empty commit/ref.")
+    changed = _run_git_diff_names([f"{since_commit}..HEAD"])
+    logger.debug(
+        "Found %d migration file(s) committed since %s", len(changed), since_commit
+    )
+    return changed
+
+
+def _files_to_app_migrations(files: list[str]) -> list[tuple[str, str]]:
+    """Map changed migration file paths to (app_label, migration_name) pairs.
+
+    The app label is resolved via Django's app registry so that apps whose
+    ``AppConfig.label`` differs from their package directory name are handled
+    correctly.
+
+    Args:
+        files: Absolute paths to changed migration files.
+
+    Returns:
+        List of (app_label, migration_name) tuples (``__init__`` skipped).
+    """
     result: list[tuple[str, str]] = []
 
     # Map resolved app package paths to their registered labels once. Using the
@@ -128,6 +173,39 @@ def get_changed_apps_and_migrations(
 
     logger.debug("Changed migrations: %s", result)
     return result
+
+
+def get_changed_apps_and_migrations(
+    base_ref: str = "main",
+) -> list[tuple[str, str]]:
+    """Get (app_label, migration_name) pairs for migrations changed vs *base_ref*.
+
+    Includes uncommitted working-tree changes (mirrors ``--diff``).
+
+    Args:
+        base_ref: Git ref to diff against.
+
+    Returns:
+        List of (app_label, migration_name) tuples.
+    """
+    return _files_to_app_migrations(get_changed_migration_files(base_ref))
+
+
+def get_committed_apps_and_migrations(
+    since_commit: str,
+) -> list[tuple[str, str]]:
+    """Get (app_label, migration_name) pairs for migrations committed since a ref.
+
+    Diffs the committed range ``<since_commit>..HEAD``; uncommitted edits are
+    ignored (mirrors ``--since-commit``).
+
+    Args:
+        since_commit: Git commit/ref marking the lower bound (exclusive).
+
+    Returns:
+        List of (app_label, migration_name) tuples.
+    """
+    return _files_to_app_migrations(get_committed_migration_files(since_commit))
 
 
 def _find_git_root() -> str:

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -116,6 +116,16 @@ class Command(BaseCommand):
             help="Only check migrations changed since BASE_REF (default: main)",
         )
         parser.add_argument(
+            "--since-commit",
+            type=str,
+            default=None,
+            metavar="COMMIT",
+            help=(
+                "Only check migrations committed in the range COMMIT..HEAD "
+                "(committed changes only; ignores the working tree)"
+            ),
+        )
+        parser.add_argument(
             "--baseline",
             type=str,
             default=None,
@@ -290,23 +300,38 @@ class Command(BaseCommand):
         issues: list[Issue] = []
 
         diff_ref = options.get("diff")
-        if diff_ref is not None:
+        since_commit = options.get("since_commit")
+        if diff_ref is not None and since_commit is not None:
+            self.stderr.write(
+                self.style.ERROR("Use only one of --diff and --since-commit.")
+            )
+            sys.exit(2)
+        if diff_ref is not None or since_commit is not None:
             from django.core.management.base import CommandError
 
             from django_safe_migrations.diff import (
                 DiffError,
                 get_changed_apps_and_migrations,
+                get_committed_apps_and_migrations,
             )
 
             try:
-                changed = get_changed_apps_and_migrations(diff_ref)
+                if since_commit is not None:
+                    changed = get_committed_apps_and_migrations(since_commit)
+                    mode_desc = f"committed since {since_commit}"
+                else:
+                    # Reachable only when diff_ref is set (the two are mutually
+                    # exclusive and at least one is non-None to enter here).
+                    assert diff_ref is not None
+                    changed = get_changed_apps_and_migrations(diff_ref)
+                    mode_desc = f"changed vs {diff_ref}"
             except DiffError as e:
                 self.stderr.write(self.style.ERROR(str(e)))
                 sys.exit(2)
 
             if verbose:
                 self.stderr.write(
-                    f"Diff mode: checking {len(changed)} changed migration(s)"
+                    f"Diff mode ({mode_desc}): checking " f"{len(changed)} migration(s)"
                 )
             for app_label, migration_name in changed:
                 if app_label in exclude_apps:

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -535,6 +535,18 @@ check-migrations:
     - python manage.py check_migrations --diff origin/main --format=gitlab > gl-code-quality-report.json
 ```
 
+For pipelines that record the last successful commit, `--since-commit` checks
+only what was **committed** in the range `COMMIT..HEAD` (ignoring any
+uncommitted working-tree edits):
+
+```yaml
+# GitHub Actions - lint only migrations committed since the last green build
+- name: Check migrations since last release
+  run: python manage.py check_migrations --since-commit "$LAST_GREEN_SHA" --format=github
+```
+
+`--diff` and `--since-commit` are mutually exclusive.
+
 ### Baseline for Existing Projects
 
 When adopting django-safe-migrations on an existing project, generate a baseline to suppress known issues:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,6 +445,26 @@ python manage.py check_migrations --diff
 python manage.py check_migrations --diff develop
 ```
 
+`--diff` compares against your **working tree**, so it also includes uncommitted
+migration edits.
+
+### `--since-commit`
+
+Only check migrations changed in the **committed range** `COMMIT..HEAD`. Unlike
+`--diff`, uncommitted working-tree edits are ignored, which makes it suited to
+incremental CI ("lint only what was committed since the last green build"):
+
+```bash
+# Check everything committed since the last successful pipeline SHA
+python manage.py check_migrations --since-commit "$LAST_GREEN_SHA"
+
+# Check what this branch added on top of main (committed only)
+python manage.py check_migrations --since-commit origin/main
+```
+
+`--diff` and `--since-commit` are mutually exclusive; passing both exits with
+code 2.
+
 ### `--baseline`
 
 Exclude issues that are present in a baseline file:

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -278,6 +278,46 @@ class TestCommandOptions:
             call_command("check_migrations", diff="main", stdout=out, stderr=err)
         assert "Skipping" in err.getvalue()
 
+    def test_since_commit_analyzes_committed_migration(self):
+        """--since-commit analyzes only migrations in the committed range."""
+        from unittest.mock import patch
+
+        out = StringIO()
+        with patch(
+            "django_safe_migrations.diff.get_committed_apps_and_migrations",
+            return_value=[("testapp", "0001_initial")],
+        ) as mock_committed:
+            try:
+                call_command(
+                    "check_migrations",
+                    since_commit="abc123",
+                    format="json",
+                    stdout=out,
+                )
+            except SystemExit:
+                pass
+
+        mock_committed.assert_called_once_with("abc123")
+        data = json.loads(out.getvalue())
+        assert "issues" in data
+        # Only the single committed migration is analyzed.
+        for issue in data["issues"]:
+            assert issue["migration_name"] == "0001_initial"
+
+    def test_diff_and_since_commit_are_mutually_exclusive(self):
+        """Passing both --diff and --since-commit exits with code 2."""
+        out, err = StringIO(), StringIO()
+        with pytest.raises(SystemExit) as exc:
+            call_command(
+                "check_migrations",
+                diff="main",
+                since_commit="abc123",
+                stdout=out,
+                stderr=err,
+            )
+        assert exc.value.code == 2
+        assert "only one of" in err.getvalue().lower()
+
     def test_exclude_apps_removes_detection(self):
         """Test --exclude-apps properly excludes apps from analysis."""
         out = StringIO()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -97,3 +97,37 @@ class TestMain:
 
         assert rc == 1
         assert "DJANGO_SETTINGS_MODULE" in err
+
+    def test_diff_and_since_commit_mutually_exclusive(self, monkeypatch, capsys):
+        """Passing both --diff and --since-commit returns exit code 2."""
+        monkeypatch.setattr(cli, "setup_django", lambda: True)
+
+        rc = cli.main(["--diff", "main", "--since-commit", "abc123"])
+        err = capsys.readouterr().err
+
+        assert rc == 2
+        assert "only one of" in err.lower()
+
+    def test_since_commit_uses_committed_range(self, monkeypatch, capsys):
+        """--since-commit routes through get_committed_apps_and_migrations."""
+        monkeypatch.setattr(cli, "setup_django", lambda: True)
+
+        from django_safe_migrations import diff as diff_mod
+
+        called = {}
+
+        def fake_committed(commit):
+            called["commit"] = commit
+            return []
+
+        monkeypatch.setattr(
+            diff_mod, "get_committed_apps_and_migrations", fake_committed
+        )
+
+        rc = cli.main(["--since-commit", "abc123", "--format=json"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert called["commit"] == "abc123"
+        # No changed migrations -> empty issue set.
+        assert json.loads(out)["total"] == 0

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -13,6 +13,8 @@ from django_safe_migrations.diff import (
     _find_git_root,
     get_changed_apps_and_migrations,
     get_changed_migration_files,
+    get_committed_apps_and_migrations,
+    get_committed_migration_files,
 )
 
 
@@ -366,3 +368,87 @@ class TestGetChangedAppsAndMigrations:
         assert "0001_initial" in migration_names
         assert "0002_add_field" in migration_names
         assert "0003_remove_field" in migration_names
+
+
+class TestGetCommittedMigrationFiles:
+    """Tests for get_committed_migration_files (committed-range diff)."""
+
+    def test_uses_committed_range(self, tmp_path):
+        """The git diff uses ``<commit>..HEAD`` so the working tree is ignored."""
+        app_dir = tmp_path / "myapp" / "migrations"
+        app_dir.mkdir(parents=True)
+        (app_dir / "0002_add_field.py").write_text("# migration")
+
+        mock_diff_result = MagicMock()
+        mock_diff_result.stdout = "myapp/migrations/0002_add_field.py\n"
+        mock_root_result = MagicMock()
+        mock_root_result.stdout = str(tmp_path) + "\n"
+
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "rev-parse" in cmd:
+                return mock_root_result
+            return mock_diff_result
+
+        with patch("django_safe_migrations.diff.subprocess.run", side_effect=mock_run):
+            files = get_committed_migration_files("abc123")
+
+        assert len(files) == 1
+        diff_cmd = next(c for c in calls if "diff" in c)
+        assert "abc123..HEAD" in diff_cmd
+
+    def test_rejects_empty_commit(self):
+        """An empty/whitespace commit is rejected before any git call."""
+        with patch("django_safe_migrations.diff.subprocess.run") as mock_run:
+            with pytest.raises(DiffError, match="non-empty"):
+                get_committed_migration_files("   ")
+        mock_run.assert_not_called()
+
+    def test_rejects_commit_starting_with_dash(self):
+        """A commit starting with '-' is rejected (argument-injection guard)."""
+        with patch("django_safe_migrations.diff.subprocess.run") as mock_run:
+            with pytest.raises(DiffError, match="may not start with"):
+                get_committed_migration_files("--output=/tmp/evil")
+        mock_run.assert_not_called()
+
+    def test_raises_diff_error_on_bad_commit(self):
+        """An unknown commit surfaces a DiffError from git."""
+        mock_root_result = MagicMock()
+        mock_root_result.stdout = "/tmp\n"
+
+        def mock_run(cmd, **kwargs):
+            if "rev-parse" in cmd:
+                return mock_root_result
+            raise subprocess.CalledProcessError(1, "git")
+
+        with patch("django_safe_migrations.diff.subprocess.run", side_effect=mock_run):
+            with pytest.raises(DiffError, match="Could not run git diff"):
+                get_committed_migration_files("deadbeef")
+
+
+class TestGetCommittedAppsAndMigrations:
+    """Tests for get_committed_apps_and_migrations."""
+
+    def test_extracts_app_and_migration(self):
+        """App labels / migration names are parsed from committed file paths."""
+        changed_files = ["/project/myapp/migrations/0002_add_email.py"]
+
+        with patch(
+            "django_safe_migrations.diff.get_committed_migration_files",
+            return_value=changed_files,
+        ):
+            result = get_committed_apps_and_migrations("abc123")
+
+        assert result == [("myapp", "0002_add_email")]
+
+    def test_forwards_commit(self):
+        """The commit is forwarded to get_committed_migration_files."""
+        with patch(
+            "django_safe_migrations.diff.get_committed_migration_files",
+            return_value=[],
+        ) as mock_fn:
+            get_committed_apps_and_migrations("v1.0.0")
+
+        mock_fn.assert_called_once_with("v1.0.0")


### PR DESCRIPTION
First of the v0.7.1 medium-priority DX batch.

## What
Adds `--since-commit COMMIT` — checks only migrations changed in the **committed range** `COMMIT..HEAD`. Unlike `--diff` (which compares against the working tree and includes uncommitted edits), `--since-commit` ignores the working tree, making it suited to incremental CI: *lint only what was committed since the last green build*.

## Why distinct from `--diff`
`--diff <ref>` = `git diff <ref>` (ref vs working tree). `--since-commit <sha>` = `git diff <sha>..HEAD` (committed range only). The two are mutually exclusive; passing both exits 2.

## Changes
- **`diff.py`**: extracted shared `_run_git_diff_names()` (git plumbing + arg-injection guard) and `_files_to_app_migrations()` (path→app/migration mapping); existing `--diff` functions now delegate to them. New `get_committed_migration_files()` / `get_committed_apps_and_migrations()` use the `<sha>..HEAD` range and reject empty/dash refs.
- **CLI + management command**: `--since-commit` flag wired into both; mutual-exclusion guard.
- **Tests**: unit (committed-range git args, empty/dash guards, app mapping) + CLI (mutual-exclusion, range routing) + command integration (analyzes only committed migration, mutual-exclusion exit 2).
- **Docs**: README (example + options table), `configuration.md` (new section + working-tree vs committed note), `ci_integration.md` (incremental-CI example), CHANGELOG `[Unreleased]`.

## Verification
791 passed, 19 skipped · pre-commit green (black/isort/flake8/bandit/mypy/mdformat).
