### PR TITLE
feat: opt-in lint result caching (--cache / --cache-file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tree), uncommitted edits are ignored — suited to incremental CI that lints
   only what was committed since the last green build. Mutually exclusive with
   `--diff`.
+- **`--cache` / `--cache-file PATH`.** Opt-in result caching that skips
+  re-analysing unchanged migrations on repeat runs. Each migration is keyed on
+  a dependency-aware content hash (its own file plus its transitive
+  dependencies), and the whole cache is namespaced by a fingerprint of the
+  package version, active rules, database vendor, Django version, `USE_TZ` and
+  resolved config — so upgrades or config changes never serve stale results.
+  Best-effort: a corrupt cache file is ignored, not fatal.
 
 ## [0.7.0] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ python manage.py check_migrations --diff main
 # Incremental - only migrations committed since a known-good commit
 python manage.py check_migrations --since-commit origin/main
 
+# Cache results to speed up repeat runs (e.g. pre-commit)
+python manage.py check_migrations --cache
+
 # Baseline - suppress existing issues
 python manage.py check_migrations --generate-baseline .migration-baseline.json
 python manage.py check_migrations --baseline .migration-baseline.json
@@ -234,6 +237,8 @@ repos:
 | `--include-django-apps`    | Include Django's built-in apps                                |
 | `--diff [BASE_REF]`        | Only check migrations changed since BASE_REF (default: main)  |
 | `--since-commit COMMIT`    | Only check migrations committed in COMMIT..HEAD (no worktree) |
+| `--cache`                  | Cache results to speed up repeat runs (`.dsm_cache.json`)     |
+| `--cache-file PATH`        | Use a custom cache file path (implies `--cache`)              |
 | `--baseline FILE`          | Exclude issues present in baseline file                       |
 | `--generate-baseline FILE` | Generate baseline file from current issues                    |
 | `--interactive`            | Interactively review each issue                               |

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import sys
 from typing import TYPE_CHECKING, Any, Optional
@@ -58,6 +59,7 @@ class MigrationAnalyzer:
         db_vendor: Optional[str] = None,
         disabled_rules: Optional[list[str]] = None,
         verbose: bool = False,
+        cache: Optional[Any] = None,
     ):
         """Initialize the analyzer.
 
@@ -69,10 +71,17 @@ class MigrationAnalyzer:
             disabled_rules: List of rule IDs to disable. If None, uses
                            SAFE_MIGRATIONS["DISABLED_RULES"] from settings.
             verbose: If True, print progress information to stderr.
+            cache: Optional ``AnalysisCache``. When set, each migration's
+                   issues are served from / stored to the cache keyed on a
+                   dependency-aware content hash.
         """
         self.db_vendor = db_vendor or get_db_vendor()
         self._disabled_rules = disabled_rules
         self.verbose = verbose
+        self.cache = cache
+        # Memoise per-file SHA-256 so each migration file is hashed once per run
+        # even though it appears in many migrations' dependency closures.
+        self._file_hash_memo: dict[str, str] = {}
         self.rules = rules or get_all_rules(self.db_vendor)
         logger.debug(
             "Initialized analyzer: db_vendor=%s, rules=%d, disabled_rules=%s",
@@ -128,6 +137,23 @@ class MigrationAnalyzer:
             app_label = getattr(migration, "app_label", None)
         if migration_name is None:
             migration_name = getattr(migration, "name", None)
+
+        # Cache lookup: serve unchanged migrations from the cache. The content
+        # hash covers this migration's file and its transitive dependencies, so
+        # changes to ancestor migrations (which feed before-state resolution)
+        # correctly invalidate the entry.
+        cache_key: Optional[str] = None
+        content_hash: Optional[str] = None
+        if self.cache is not None and app_label and migration_name:
+            content_hash = self._migration_content_hash(
+                migration, app_label, migration_name, loader
+            )
+            if content_hash is not None:
+                cache_key = f"{app_label}:{migration_name}"
+                cached: Optional[list[Issue]] = self.cache.get(cache_key, content_hash)
+                if cached is not None:
+                    logger.debug("Cache hit for %s", cache_key)
+                    return cached
 
         operations = getattr(migration, "operations", [])
         logger.debug(
@@ -202,7 +228,80 @@ class MigrationAnalyzer:
             migration_name,
             len(issues),
         )
+
+        # Store the freshly computed result for next time.
+        if (
+            self.cache is not None
+            and cache_key is not None
+            and content_hash is not None
+        ):
+            self.cache.set(cache_key, content_hash, issues)
+
         return issues
+
+    def _migration_content_hash(
+        self,
+        migration: Migration,
+        app_label: str,
+        migration_name: str,
+        loader: Any,
+    ) -> Optional[str]:
+        """Compute a dependency-aware content hash for a migration.
+
+        The hash combines the SHA-256 of the migration's own source file with
+        those of its transitive dependencies (the graph ``forwards_plan``), so
+        a change to any ancestor — which can alter before-state resolution —
+        invalidates the entry. Returns ``None`` (uncacheable) if any file in
+        the closure cannot be located or read, or if the graph cannot resolve
+        the node (e.g. squashed/replaced migrations).
+
+        Args:
+            migration: The migration being analysed.
+            app_label: Its app label.
+            migration_name: Its migration name.
+            loader: The active ``MigrationLoader`` (provides the graph).
+
+        Returns:
+            A hex digest, or ``None`` if the migration is not safely cacheable.
+        """
+        from django_safe_migrations.cache import file_sha256
+
+        # Resolve the dependency closure to a deterministic list of file paths.
+        paths: list[str] = []
+        node = (app_label, migration_name)
+        try:
+            graph = getattr(loader, "graph", None)
+            if graph is not None and node in getattr(graph, "nodes", {}):
+                plan = graph.forwards_plan(node)
+                for dep in plan:
+                    obj = loader.disk_migrations.get(dep)
+                    if obj is None:
+                        return None
+                    dep_path = get_migration_file_path(obj)
+                    if not dep_path:
+                        return None
+                    paths.append(dep_path)
+            else:
+                # No usable graph node: fall back to the migration's own file.
+                own = get_migration_file_path(migration)
+                if not own:
+                    return None
+                paths = [own]
+        except Exception:  # noqa: BLE001 - any graph error => uncacheable
+            return None
+
+        digest = hashlib.sha256()
+        for path in paths:
+            file_hash = self._file_hash_memo.get(path)
+            if file_hash is None:
+                try:
+                    file_hash = file_sha256(path)
+                except OSError:
+                    return None
+                self._file_hash_memo[path] = file_hash
+            digest.update(file_hash.encode("ascii"))
+            digest.update(b"\0")
+        return digest.hexdigest()
 
     def _check_operation(
         self,

--- a/django_safe_migrations/cache.py
+++ b/django_safe_migrations/cache.py
@@ -1,0 +1,178 @@
+"""Lint result caching.
+
+Caches per-migration analysis results so unchanged migrations are not
+re-analysed on subsequent runs. Opt-in via ``--cache`` / ``--cache-file``.
+
+Correctness
+-----------
+Each migration's cache entry is keyed on a content hash that combines the
+migration's own source file with the source files of its **transitive
+dependencies** (its ``forwards_plan`` in the migration graph). This means an
+``AlterField`` whose historical field state lives in an ancestor migration is
+correctly invalidated whenever that ancestor changes — not just when the
+migration's own file changes.
+
+The whole cache is namespaced by a *fingerprint* of everything else that can
+change a result: the package version, the active rule IDs, the database vendor,
+the Django version, ``USE_TZ`` and a hash of the resolved configuration. A
+fingerprint mismatch discards the entire cache, so upgrades / config changes
+never serve stale results.
+
+The cache is best-effort: any I/O or graph error degrades to "analyse normally"
+rather than raising.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from django_safe_migrations.rules.base import Issue
+
+logger = logging.getLogger("django_safe_migrations")
+
+CACHE_VERSION = 1
+DEFAULT_CACHE_FILE = ".dsm_cache.json"
+
+
+def file_sha256(path: str) -> str:
+    """Return the hex SHA-256 of a file's bytes (streamed)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_fingerprint(db_vendor: str, rule_ids: list[str]) -> str:
+    """Compute a fingerprint that namespaces the cache.
+
+    Any change to the things below must invalidate the entire cache because
+    they can change analysis results without any migration file changing.
+
+    Args:
+        db_vendor: The active database vendor.
+        rule_ids: The rule IDs that are active for this run (already reflects
+            DISABLED_RULES, db-vendor gating and Django-version gating).
+
+    Returns:
+        A hex digest uniquely identifying this analysis configuration.
+    """
+    import django
+    from django.conf import settings
+
+    from django_safe_migrations import __version__
+    from django_safe_migrations.conf import get_config
+
+    try:
+        config_blob = json.dumps(get_config(), sort_keys=True, default=repr)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        config_blob = repr(get_config())
+
+    parts = {
+        "cache_version": CACHE_VERSION,
+        "package": __version__,
+        "django": django.get_version(),
+        "vendor": db_vendor,
+        "use_tz": bool(getattr(settings, "USE_TZ", False)),
+        "rules": sorted(rule_ids),
+        "config": hashlib.sha256(config_blob.encode("utf-8")).hexdigest(),
+    }
+    blob = json.dumps(parts, sort_keys=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+class AnalysisCache:
+    """An on-disk cache of per-migration analysis results.
+
+    Entries are keyed by ``"<app_label>:<migration_name>"`` and validated by a
+    dependency-aware content hash. The whole file is namespaced by a
+    *fingerprint*; a mismatch discards every entry on load.
+    """
+
+    def __init__(self, path: str, fingerprint: str):
+        """Initialise the cache, loading any compatible entries from disk.
+
+        Args:
+            path: Path to the cache file.
+            fingerprint: The current analysis fingerprint (see
+                :func:`compute_fingerprint`).
+        """
+        self.path = Path(path)
+        self.fingerprint = fingerprint
+        self._entries: dict[str, dict[str, Any]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Ignoring unreadable cache %s: %s", self.path, exc)
+            return
+        if (
+            data.get("cache_version") != CACHE_VERSION
+            or data.get("fingerprint") != self.fingerprint
+        ):
+            logger.debug("Cache fingerprint/version mismatch; starting fresh")
+            return
+        entries = data.get("entries")
+        if isinstance(entries, dict):
+            self._entries = entries
+
+    def get(self, key: str, content_hash: str) -> Optional[list[Issue]]:
+        """Return cached issues for *key* if the content hash matches.
+
+        Args:
+            key: The migration cache key.
+            content_hash: The dependency-aware content hash for the migration.
+
+        Returns:
+            The reconstructed issue list on a hit, else ``None``.
+        """
+        from django_safe_migrations.rules.base import Issue
+
+        entry = self._entries.get(key)
+        if entry is None or entry.get("hash") != content_hash:
+            self._misses += 1
+            return None
+        self._hits += 1
+        return [Issue.from_dict(d) for d in entry.get("issues", [])]
+
+    def set(self, key: str, content_hash: str, issues: list[Issue]) -> None:
+        """Store *issues* for *key* under *content_hash*."""
+        self._entries[key] = {
+            "hash": content_hash,
+            "issues": [issue.to_dict() for issue in issues],
+        }
+
+    def save(self) -> None:
+        """Write the cache to disk (best-effort)."""
+        data = {
+            "cache_version": CACHE_VERSION,
+            "fingerprint": self.fingerprint,
+            "entries": self._entries,
+        }
+        try:
+            self.path.write_text(
+                json.dumps(data, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.warning("Could not write cache %s: %s", self.path, exc)
+
+    @property
+    def hits(self) -> int:
+        """Number of cache hits this run."""
+        return self._hits
+
+    @property
+    def misses(self) -> int:
+        """Number of cache misses this run."""
+        return self._misses

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -11,6 +11,8 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
+from django_safe_migrations.cache import DEFAULT_CACHE_FILE as _DEFAULT_CACHE_FILE
+
 if TYPE_CHECKING:
     from argparse import Namespace
 
@@ -244,6 +246,21 @@ Documentation: https://django-safe-migrations.readthedocs.io/
         metavar="SM002,SM003",
         help="Comma-separated rule IDs whose warnings should fail (exit 1)",
     )
+    parser.add_argument(
+        "--cache",
+        action="store_true",
+        help=(
+            "Cache analysis results to speed up repeat runs (default file: "
+            f"{_DEFAULT_CACHE_FILE})"
+        ),
+    )
+    parser.add_argument(
+        "--cache-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to the cache file (implies --cache)",
+    )
 
     args: Namespace = parser.parse_args(argv)
 
@@ -300,6 +317,19 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     # Create analyzer
     db_vendor_override = args.database_vendor or get_database_vendor()
     analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=args.verbose)
+
+    # Optional result cache (--cache / --cache-file). Opt-in; namespaced by a
+    # fingerprint so upgrades / config changes never serve stale results.
+    cache = None
+    if args.cache or args.cache_file:
+        from django_safe_migrations.cache import AnalysisCache, compute_fingerprint
+
+        cache_path = args.cache_file or _DEFAULT_CACHE_FILE
+        fingerprint = compute_fingerprint(
+            analyzer.db_vendor, [r.rule_id for r in analyzer.rules]
+        )
+        cache = AnalysisCache(cache_path, fingerprint)
+        analyzer.cache = cache
 
     warnings_as_errors = set(get_warnings_as_errors())
     if args.warnings_as_errors:
@@ -360,6 +390,15 @@ Documentation: https://django-safe-migrations.readthedocs.io/
                 issues.extend(analyzer.analyze_app(app_label))
     else:
         issues.extend(analyzer.analyze_all(exclude_apps=exclude_apps))
+
+    # Persist the cache (best-effort) once analysis is complete.
+    if cache is not None:
+        cache.save()
+        if args.verbose:
+            print(
+                f"Cache: {cache.hits} hit(s), {cache.misses} miss(es)",
+                file=sys.stderr,
+            )
 
     # Apply baseline filtering
     if args.baseline:

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -157,6 +157,18 @@ class Command(BaseCommand):
             metavar="SM002,SM003",
             help="Comma-separated rule IDs whose warnings should fail (exit 1)",
         )
+        parser.add_argument(
+            "--cache",
+            action="store_true",
+            help="Cache analysis results to speed up repeat runs",
+        )
+        parser.add_argument(
+            "--cache-file",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help="Path to the cache file (implies --cache)",
+        )
 
     def list_rules(self, output_format: str) -> None:
         """List all available rules.
@@ -296,6 +308,23 @@ class Command(BaseCommand):
         # Create analyzer
         analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=verbose)
 
+        # Optional result cache (--cache / --cache-file). Opt-in; namespaced by
+        # a fingerprint so upgrades / config changes never serve stale results.
+        cache = None
+        if options.get("cache") or options.get("cache_file"):
+            from django_safe_migrations.cache import (
+                DEFAULT_CACHE_FILE,
+                AnalysisCache,
+                compute_fingerprint,
+            )
+
+            cache_path = options.get("cache_file") or DEFAULT_CACHE_FILE
+            fingerprint = compute_fingerprint(
+                analyzer.db_vendor, [r.rule_id for r in analyzer.rules]
+            )
+            cache = AnalysisCache(cache_path, fingerprint)
+            analyzer.cache = cache
+
         # Collect issues
         issues: list[Issue] = []
 
@@ -373,6 +402,14 @@ class Command(BaseCommand):
                     issues.extend(analyzer.analyze_app(app_label))
         else:
             issues.extend(analyzer.analyze_all(exclude_apps=exclude_apps))
+
+        # Persist the cache (best-effort) once analysis is complete.
+        if cache is not None:
+            cache.save()
+            if verbose:
+                self.stderr.write(
+                    f"Cache: {cache.hits} hit(s), {cache.misses} miss(es)"
+                )
 
         # Apply baseline filtering
         baseline_path = options.get("baseline")

--- a/django_safe_migrations/rules/base.py
+++ b/django_safe_migrations/rules/base.py
@@ -79,6 +79,32 @@ class Issue:
             "operation_index": self.operation_index,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Issue":
+        """Reconstruct an Issue from its :meth:`to_dict` representation.
+
+        Used by the analysis cache to round-trip issues to/from disk. The
+        ``severity`` value is mapped back to the :class:`Severity` enum.
+
+        Args:
+            data: A dict produced by :meth:`to_dict`.
+
+        Returns:
+            The reconstructed :class:`Issue`.
+        """
+        return cls(
+            rule_id=data["rule_id"],
+            severity=Severity(data["severity"]),
+            operation=data["operation"],
+            message=data["message"],
+            suggestion=data.get("suggestion"),
+            file_path=data.get("file_path"),
+            line_number=data.get("line_number"),
+            app_label=data.get("app_label"),
+            migration_name=data.get("migration_name"),
+            operation_index=data.get("operation_index"),
+        )
+
 
 class BaseRule(ABC):
     """Base class for all migration rules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -461,6 +461,7 @@ django_safe_migrations/
 ├── analyzer.py              # Core MigrationAnalyzer
 ├── apps.py                  # Django AppConfig
 ├── baseline.py              # Baseline support for suppressing known issues
+├── cache.py                 # Opt-in result cache (dependency-aware, fingerprinted)
 ├── cli.py                   # Standalone CLI
 ├── conf.py                  # Configuration handling
 ├── diff.py                  # Git-based diff mode for checking only changed migrations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -465,6 +465,34 @@ python manage.py check_migrations --since-commit origin/main
 `--diff` and `--since-commit` are mutually exclusive; passing both exits with
 code 2.
 
+### `--cache` / `--cache-file`
+
+Cache analysis results so unchanged migrations are not re-analysed on the next
+run. This is useful for pre-commit hooks and CI steps that run repeatedly:
+
+```bash
+# Use the default cache file (.dsm_cache.json in the working directory)
+python manage.py check_migrations --cache
+
+# Use a custom cache location (implies --cache)
+python manage.py check_migrations --cache-file .cache/dsm.json
+```
+
+How it stays correct:
+
+- Each migration's cache entry is keyed on a content hash that combines the
+  migration's own file **and the files of its transitive dependencies**, so a
+  change to an ancestor migration (which can change before-state resolution)
+  invalidates the entry.
+- The whole cache is namespaced by a *fingerprint* of the package version, the
+  active rule IDs, the database vendor, the Django version, `USE_TZ` and the
+  resolved configuration. Any change to these discards the entire cache, so an
+  upgrade or config change never serves stale results.
+
+The cache is **opt-in** and best-effort: an unreadable or corrupt cache file is
+ignored rather than failing the run. The cache file is safe to delete at any
+time and should usually be added to `.gitignore`.
+
 ### `--baseline`
 
 Exclude issues that are present in a baseline file:

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -318,6 +318,33 @@ class TestCommandOptions:
         assert exc.value.code == 2
         assert "only one of" in err.getvalue().lower()
 
+    def test_cache_file_written_and_reused(self, tmp_path):
+        """--cache-file writes a cache file and a second run reuses it."""
+        cache_file = tmp_path / "dsm.json"
+
+        def run():
+            out = StringIO()
+            try:
+                call_command(
+                    "check_migrations",
+                    "testapp",
+                    format="json",
+                    cache_file=str(cache_file),
+                    stdout=out,
+                )
+            except SystemExit:
+                pass
+            return json.loads(out.getvalue())
+
+        first = run()
+        assert cache_file.exists()
+        cached = json.loads(cache_file.read_text())
+        assert cached["entries"]  # something got cached
+
+        # Second run produces identical results (served from cache).
+        second = run()
+        assert first["issues"] == second["issues"]
+
     def test_exclude_apps_removes_detection(self):
         """Test --exclude-apps properly excludes apps from analysis."""
         out = StringIO()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,198 @@
+"""Tests for lint result caching (django_safe_migrations.cache)."""
+
+from __future__ import annotations
+
+import json
+
+from django_safe_migrations.analyzer import MigrationAnalyzer
+from django_safe_migrations.cache import (
+    CACHE_VERSION,
+    AnalysisCache,
+    compute_fingerprint,
+    file_sha256,
+)
+from django_safe_migrations.rules.base import Issue, Severity
+
+
+def _issue(rule_id="SM001", **kw):
+    defaults = dict(
+        rule_id=rule_id,
+        severity=Severity.WARNING,
+        operation="AddField",
+        message="msg",
+        suggestion="fix it",
+        file_path="/x/migrations/0001_initial.py",
+        line_number=7,
+        app_label="testapp",
+        migration_name="0001_initial",
+        operation_index=0,
+    )
+    defaults.update(kw)
+    return Issue(**defaults)
+
+
+class TestFileSha256:
+    """Tests for file_sha256."""
+
+    def test_hashes_file_bytes(self, tmp_path):
+        """The digest matches hashlib over the same bytes."""
+        import hashlib
+
+        p = tmp_path / "m.py"
+        p.write_bytes(b"some migration content")
+        assert (
+            file_sha256(str(p)) == hashlib.sha256(b"some migration content").hexdigest()
+        )
+
+    def test_changes_with_content(self, tmp_path):
+        """Different content yields a different digest."""
+        a = tmp_path / "a.py"
+        b = tmp_path / "b.py"
+        a.write_text("aaa")
+        b.write_text("bbb")
+        assert file_sha256(str(a)) != file_sha256(str(b))
+
+
+class TestFingerprint:
+    """Tests for compute_fingerprint."""
+
+    def test_stable_for_same_inputs(self):
+        """Identical inputs produce identical fingerprints."""
+        fp1 = compute_fingerprint("postgresql", ["SM001", "SM002"])
+        fp2 = compute_fingerprint("postgresql", ["SM002", "SM001"])  # order-independent
+        assert fp1 == fp2
+
+    def test_differs_by_vendor(self):
+        """Changing the vendor changes the fingerprint."""
+        assert compute_fingerprint("postgresql", ["SM001"]) != compute_fingerprint(
+            "mysql", ["SM001"]
+        )
+
+    def test_differs_by_ruleset(self):
+        """Changing the active rule set changes the fingerprint."""
+        assert compute_fingerprint("postgresql", ["SM001"]) != compute_fingerprint(
+            "postgresql", ["SM001", "SM002"]
+        )
+
+
+class TestIssueRoundTrip:
+    """Issue.to_dict / from_dict round-trips for the cache."""
+
+    def test_round_trip_preserves_all_fields(self):
+        """from_dict(to_dict(issue)) reproduces every field, severity enum included."""
+        issue = _issue()
+        restored = Issue.from_dict(issue.to_dict())
+        assert restored == issue
+        assert restored.severity is Severity.WARNING
+
+    def test_round_trip_with_nones(self):
+        """Optional fields left as None survive the round-trip."""
+        issue = _issue(suggestion=None, line_number=None, operation_index=None)
+        assert Issue.from_dict(issue.to_dict()) == issue
+
+
+class TestAnalysisCache:
+    """Tests for the AnalysisCache store."""
+
+    def test_set_get_round_trip(self, tmp_path):
+        """A stored entry is returned for a matching content hash."""
+        cache = AnalysisCache(str(tmp_path / "c.json"), "fp")
+        cache.set("testapp:0001_initial", "hash1", [_issue()])
+
+        got = cache.get("testapp:0001_initial", "hash1")
+        assert got == [_issue()]
+        assert cache.hits == 1
+        assert cache.misses == 0
+
+    def test_miss_on_hash_mismatch(self, tmp_path):
+        """A changed content hash is a miss (the migration must be re-analysed)."""
+        cache = AnalysisCache(str(tmp_path / "c.json"), "fp")
+        cache.set("testapp:0001_initial", "hash1", [_issue()])
+
+        assert cache.get("testapp:0001_initial", "hash2") is None
+        assert cache.misses == 1
+
+    def test_miss_on_unknown_key(self, tmp_path):
+        """An unknown key is a miss."""
+        cache = AnalysisCache(str(tmp_path / "c.json"), "fp")
+        assert cache.get("nope:0001", "h") is None
+
+    def test_save_and_reload(self, tmp_path):
+        """Entries persist across instances sharing the same file + fingerprint."""
+        path = str(tmp_path / "c.json")
+        cache = AnalysisCache(path, "fp")
+        cache.set("testapp:0001_initial", "hash1", [_issue()])
+        cache.save()
+
+        reloaded = AnalysisCache(path, "fp")
+        assert reloaded.get("testapp:0001_initial", "hash1") == [_issue()]
+
+    def test_fingerprint_mismatch_discards(self, tmp_path):
+        """A different fingerprint discards all entries on load."""
+        path = str(tmp_path / "c.json")
+        cache = AnalysisCache(path, "fp-old")
+        cache.set("testapp:0001_initial", "hash1", [_issue()])
+        cache.save()
+
+        reloaded = AnalysisCache(path, "fp-new")
+        assert reloaded.get("testapp:0001_initial", "hash1") is None
+
+    def test_corrupt_cache_is_ignored(self, tmp_path):
+        """An unreadable / corrupt cache file is ignored, not fatal."""
+        path = tmp_path / "c.json"
+        path.write_text("{ this is not json")
+        cache = AnalysisCache(str(path), "fp")
+        assert cache.get("any", "h") is None  # starts empty
+
+    def test_saved_file_records_version_and_fingerprint(self, tmp_path):
+        """The persisted file records cache_version and fingerprint."""
+        path = tmp_path / "c.json"
+        cache = AnalysisCache(str(path), "fp123")
+        cache.set("k", "h", [_issue()])
+        cache.save()
+
+        data = json.loads(path.read_text())
+        assert data["cache_version"] == CACHE_VERSION
+        assert data["fingerprint"] == "fp123"
+        assert "k" in data["entries"]
+
+
+class TestAnalyzerCaching:
+    """End-to-end: the analyzer serves unchanged migrations from the cache."""
+
+    def _fingerprint(self, analyzer):
+        return compute_fingerprint(
+            analyzer.db_vendor, [r.rule_id for r in analyzer.rules]
+        )
+
+    def test_second_run_hits_and_matches(self, tmp_path):
+        """A second run (fresh instance, same file) hits cache with identical issues."""
+        path = str(tmp_path / "c.json")
+
+        a1 = MigrationAnalyzer()
+        a1.cache = AnalysisCache(path, self._fingerprint(a1))
+        issues1 = a1.analyze_app("testapp")
+        a1.cache.save()
+
+        assert a1.cache.misses > 0
+        assert a1.cache.hits == 0
+
+        a2 = MigrationAnalyzer()
+        a2.cache = AnalysisCache(path, self._fingerprint(a2))
+        issues2 = a2.analyze_app("testapp")
+
+        # Every migration served from cache, no fresh analysis.
+        assert a2.cache.hits > 0
+        assert a2.cache.misses == 0
+        # Results are identical to the uncached run.
+        assert [i.to_dict() for i in issues1] == [i.to_dict() for i in issues2]
+
+    def test_cached_equals_uncached(self, tmp_path):
+        """Cache-enabled output equals cache-disabled output (correctness)."""
+        uncached = MigrationAnalyzer().analyze_app("testapp")
+
+        a = MigrationAnalyzer()
+        a.cache = AnalysisCache(str(tmp_path / "c.json"), self._fingerprint(a))
+        cached = a.analyze_app("testapp")
+
+        assert [i.to_dict() for i in uncached] == [i.to_dict() for i in cached]


### PR DESCRIPTION
Second of the v0.7.1 medium-priority DX batch.

## What
Opt-in result caching that skips re-analysing **unchanged** migrations on repeat runs (pre-commit hooks, CI steps that run every push). Enabled with `--cache` (default file `.dsm_cache.json`) or `--cache-file PATH`.

## Correctness (the hard part)
Caching a linter is only useful if it never serves a stale result. Two layers guard that:

1. **Dependency-aware per-migration key.** Each migration's entry is keyed on a content hash combining its own source file **and the files of its transitive dependencies** (the migration graph's `forwards_plan`). So an `AlterField` whose historical field state lives in an ancestor migration is invalidated when *that ancestor* changes — not only when the migration's own file changes. Changing a leaf migration re-analyses just that migration; changing a root correctly re-analyses everything downstream.
2. **Global fingerprint namespace.** The whole cache is namespaced by a fingerprint of: package version, active rule IDs, database vendor, Django version, `USE_TZ`, and a hash of the resolved configuration. Any change discards the entire cache — so upgrades or config edits never serve stale results.

Best-effort and safe: squashed/replaced migrations and unreadable files are treated as uncacheable (analysed normally), and a corrupt cache file is ignored rather than fatal.

## Changes
- **`cache.py`** (new): `AnalysisCache` (on-disk JSON store), `compute_fingerprint()`, `file_sha256()`.
- **`analyzer.py`**: optional `cache` param; lookup/store in `analyze_migration`; per-run file-hash memo; `_migration_content_hash()` with graph-aware closure + safe fallbacks.
- **`rules/base.py`**: `Issue.from_dict()` to round-trip cached issues.
- **CLI + management command**: `--cache` / `--cache-file` flags; verbose prints hit/miss stats; cache saved after analysis.
- **Tests**: cache unit (round-trip, fingerprint stability/variance, hash-mismatch miss, fingerprint-mismatch discard, corrupt-file tolerance) + analyzer end-to-end (**second run is all hits**, **cached output == uncached output**) + command integration (file written + reused).
- **Docs**: README (example + options table), `configuration.md` (`--cache`/`--cache-file` section), `architecture.md`, CHANGELOG `[Unreleased]`.

## Verification
808 passed, 19 skipped · pre-commit green (black/isort/flake8/bandit/mypy/mdformat).
