### PR TITLE
feat: --check-reverse (reverse-migration safety, RV0xx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package version, active rules, database vendor, Django version, `USE_TZ` and
   resolved config — so upgrades or config changes never serve stale results.
   Best-effort: a corrupt cache file is ignored, not fatal.
+- **`--check-reverse`.** Also analyse each migration's rollback path and report
+  destructive reverse operations under a new `RV0xx` family: `RV001`
+  (`AddField` → `DROP COLUMN`), `RV002` (`CreateModel` → `DROP TABLE`), `RV003`
+  (`AddIndex` → `DROP INDEX`), `RV004` (`AddConstraint` → `DROP CONSTRAINT`).
+  Distinct from `SM007`/`SM016` (which flag operations that cannot be reversed
+  at all); fires only when the flag is given.
 
 ## [0.7.0] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ python manage.py check_migrations --since-commit origin/main
 # Cache results to speed up repeat runs (e.g. pre-commit)
 python manage.py check_migrations --cache
 
+# Reverse safety - check whether rolling back is destructive
+python manage.py check_migrations --check-reverse
+
 # Baseline - suppress existing issues
 python manage.py check_migrations --generate-baseline .migration-baseline.json
 python manage.py check_migrations --baseline .migration-baseline.json
@@ -239,6 +242,7 @@ repos:
 | `--since-commit COMMIT`    | Only check migrations committed in COMMIT..HEAD (no worktree) |
 | `--cache`                  | Cache results to speed up repeat runs (`.dsm_cache.json`)     |
 | `--cache-file PATH`        | Use a custom cache file path (implies `--cache`)              |
+| `--check-reverse`          | Also check the rollback path for destructive ops (RV0xx)      |
 | `--baseline FILE`          | Exclude issues present in baseline file                       |
 | `--generate-baseline FILE` | Generate baseline file from current issues                    |
 | `--interactive`            | Interactively review each issue                               |

--- a/django_safe_migrations/analyzer.py
+++ b/django_safe_migrations/analyzer.py
@@ -60,6 +60,7 @@ class MigrationAnalyzer:
         disabled_rules: Optional[list[str]] = None,
         verbose: bool = False,
         cache: Optional[Any] = None,
+        check_reverse: bool = False,
     ):
         """Initialize the analyzer.
 
@@ -74,11 +75,14 @@ class MigrationAnalyzer:
             cache: Optional ``AnalysisCache``. When set, each migration's
                    issues are served from / stored to the cache keyed on a
                    dependency-aware content hash.
+            check_reverse: If True, also analyse each migration's rollback
+                   path for destructive operations (RV0xx issues).
         """
         self.db_vendor = db_vendor or get_db_vendor()
         self._disabled_rules = disabled_rules
         self.verbose = verbose
         self.cache = cache
+        self.check_reverse = check_reverse
         # Memoise per-file SHA-256 so each migration file is hashed once per run
         # even though it appears in many migrations' dependency closures.
         self._file_hash_memo: dict[str, str] = {}
@@ -221,6 +225,19 @@ class MigrationAnalyzer:
                 if issue.migration_name is None:
                     issue.migration_name = migration_name
                 issues.append(issue)
+
+        # Reverse-safety pass: analyse the rollback path (opt-in).
+        if self.check_reverse:
+            from django_safe_migrations.reverse import analyze_reverse_safety
+
+            issues.extend(
+                analyze_reverse_safety(
+                    migration=migration,
+                    app_label=app_label,
+                    migration_name=migration_name,
+                    file_path=file_path,
+                )
+            )
 
         logger.debug(
             "Migration %s.%s analysis complete: %d issues found",

--- a/django_safe_migrations/cache.py
+++ b/django_safe_migrations/cache.py
@@ -48,7 +48,11 @@ def file_sha256(path: str) -> str:
     return h.hexdigest()
 
 
-def compute_fingerprint(db_vendor: str, rule_ids: list[str]) -> str:
+def compute_fingerprint(
+    db_vendor: str,
+    rule_ids: list[str],
+    check_reverse: bool = False,
+) -> str:
     """Compute a fingerprint that namespaces the cache.
 
     Any change to the things below must invalidate the entire cache because
@@ -58,6 +62,8 @@ def compute_fingerprint(db_vendor: str, rule_ids: list[str]) -> str:
         db_vendor: The active database vendor.
         rule_ids: The rule IDs that are active for this run (already reflects
             DISABLED_RULES, db-vendor gating and Django-version gating).
+        check_reverse: Whether reverse-safety analysis is enabled (it adds
+            ``RV0xx`` issues, so on/off must produce different fingerprints).
 
     Returns:
         A hex digest uniquely identifying this analysis configuration.
@@ -80,6 +86,7 @@ def compute_fingerprint(db_vendor: str, rule_ids: list[str]) -> str:
         "vendor": db_vendor,
         "use_tz": bool(getattr(settings, "USE_TZ", False)),
         "rules": sorted(rule_ids),
+        "check_reverse": bool(check_reverse),
         "config": hashlib.sha256(config_blob.encode("utf-8")).hexdigest(),
     }
     blob = json.dumps(parts, sort_keys=True)

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -261,6 +261,14 @@ Documentation: https://django-safe-migrations.readthedocs.io/
         metavar="PATH",
         help="Path to the cache file (implies --cache)",
     )
+    parser.add_argument(
+        "--check-reverse",
+        action="store_true",
+        help=(
+            "Also check each migration's rollback path for destructive "
+            "operations (RV0xx issues)"
+        ),
+    )
 
     args: Namespace = parser.parse_args(argv)
 
@@ -316,7 +324,11 @@ Documentation: https://django-safe-migrations.readthedocs.io/
 
     # Create analyzer
     db_vendor_override = args.database_vendor or get_database_vendor()
-    analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=args.verbose)
+    analyzer = MigrationAnalyzer(
+        db_vendor=db_vendor_override,
+        verbose=args.verbose,
+        check_reverse=args.check_reverse,
+    )
 
     # Optional result cache (--cache / --cache-file). Opt-in; namespaced by a
     # fingerprint so upgrades / config changes never serve stale results.
@@ -326,7 +338,9 @@ Documentation: https://django-safe-migrations.readthedocs.io/
 
         cache_path = args.cache_file or _DEFAULT_CACHE_FILE
         fingerprint = compute_fingerprint(
-            analyzer.db_vendor, [r.rule_id for r in analyzer.rules]
+            analyzer.db_vendor,
+            [r.rule_id for r in analyzer.rules],
+            check_reverse=analyzer.check_reverse,
         )
         cache = AnalysisCache(cache_path, fingerprint)
         analyzer.cache = cache

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -169,6 +169,14 @@ class Command(BaseCommand):
             metavar="PATH",
             help="Path to the cache file (implies --cache)",
         )
+        parser.add_argument(
+            "--check-reverse",
+            action="store_true",
+            help=(
+                "Also check each migration's rollback path for destructive "
+                "operations (RV0xx issues)"
+            ),
+        )
 
     def list_rules(self, output_format: str) -> None:
         """List all available rules.
@@ -306,7 +314,11 @@ class Command(BaseCommand):
             exclude_apps = list(set(exclude_apps + django_apps))
 
         # Create analyzer
-        analyzer = MigrationAnalyzer(db_vendor=db_vendor_override, verbose=verbose)
+        analyzer = MigrationAnalyzer(
+            db_vendor=db_vendor_override,
+            verbose=verbose,
+            check_reverse=options.get("check_reverse", False),
+        )
 
         # Optional result cache (--cache / --cache-file). Opt-in; namespaced by
         # a fingerprint so upgrades / config changes never serve stale results.
@@ -320,7 +332,9 @@ class Command(BaseCommand):
 
             cache_path = options.get("cache_file") or DEFAULT_CACHE_FILE
             fingerprint = compute_fingerprint(
-                analyzer.db_vendor, [r.rule_id for r in analyzer.rules]
+                analyzer.db_vendor,
+                [r.rule_id for r in analyzer.rules],
+                check_reverse=analyzer.check_reverse,
             )
             cache = AnalysisCache(cache_path, fingerprint)
             analyzer.cache = cache

--- a/django_safe_migrations/reverse.py
+++ b/django_safe_migrations/reverse.py
@@ -1,0 +1,168 @@
+"""Reverse-migration safety checks (``--check-reverse``).
+
+A migration can be perfectly *reversible* (Django can generate the backwards
+operations) yet have a rollback path that is itself **dangerous in
+production**. Rolling back an additive migration runs the destructive inverse:
+
+- a forward ``AddField`` reverses to ``DROP COLUMN`` (data loss),
+- a forward ``CreateModel`` reverses to ``DROP TABLE`` (data loss),
+- a forward ``AddIndex`` reverses to ``DROP INDEX`` (a brief lock),
+- a forward ``AddConstraint`` reverses to ``DROP CONSTRAINT``.
+
+These checks are **distinct** from SM007 / SM016, which flag ``RunSQL`` /
+``RunPython`` that cannot be reversed *at all*. They run only when the user
+opts in with ``--check-reverse`` and emit issues under the ``RV0xx`` family so
+they are never confused with the forward (``SM0xx``) rules.
+
+Scope: only operations whose reverse is unambiguous **without reconstructing
+lost state** are reported. Reverses that need historical state (``RemoveField``
+re-adding a column, ``DeleteModel`` recreating a table, ``AlterField``
+restoring the old field) are intentionally out of scope to avoid guessing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from django_safe_migrations.rules.base import Issue, Severity
+
+if TYPE_CHECKING:
+    from django.db.migrations import Migration
+
+logger = logging.getLogger("django_safe_migrations")
+
+
+def _check_operation_reverse(operation: object) -> Optional[Issue]:
+    """Return a reverse-safety Issue for one operation, or None.
+
+    Args:
+        operation: A Django migration operation.
+
+    Returns:
+        An :class:`Issue` describing the danger on rollback, else ``None``.
+    """
+    from django.db import migrations
+    from django.db.migrations import operations as ops
+
+    # AddField -> reverse drops the column (and its data).
+    if isinstance(operation, ops.AddField):
+        model = getattr(operation, "model_name", "?")
+        name = getattr(operation, "name", "?")
+        return Issue(
+            rule_id="RV001",
+            severity=Severity.WARNING,
+            operation=f"AddField({model}.{name})",
+            message=(
+                f"Rolling back this migration drops column "
+                f"'{model}.{name}' — any data written to it since deploy "
+                f"is lost."
+            ),
+            suggestion=(
+                "If the rollback path matters, split the change so the column "
+                "is removed in a later, separate migration, or accept that a "
+                "rollback is destructive and document it."
+            ),
+        )
+
+    # CreateModel -> reverse drops the whole table.
+    if isinstance(operation, ops.CreateModel):
+        model = getattr(operation, "name", "?")
+        return Issue(
+            rule_id="RV002",
+            severity=Severity.WARNING,
+            operation=f"CreateModel({model})",
+            message=(
+                f"Rolling back this migration drops the table for model "
+                f"'{model}' and all of its rows."
+            ),
+            suggestion=(
+                "Rolling back a CreateModel is destructive by nature. Make "
+                "sure the rollback is intentional and the data is expendable "
+                "(or backed up) before relying on it."
+            ),
+        )
+
+    # AddIndex -> reverse drops the index (briefly locks the table).
+    if isinstance(operation, ops.AddIndex):
+        model = getattr(operation, "model_name", "?")
+        index = getattr(operation, "index", None)
+        index_name = getattr(index, "name", "?")
+        return Issue(
+            rule_id="RV003",
+            severity=Severity.INFO,
+            operation=f"AddIndex({model}.{index_name})",
+            message=(
+                f"Rolling back this migration drops index '{index_name}'. "
+                f"DROP INDEX takes a brief exclusive lock; on a large table "
+                f"this can stall queries during the rollback."
+            ),
+            suggestion=(
+                "On PostgreSQL, reverse a concurrently-created index with "
+                "DROP INDEX CONCURRENTLY (via a hand-written RunSQL reverse) "
+                "to avoid the lock."
+            ),
+        )
+
+    # AddConstraint -> reverse drops the constraint.
+    if isinstance(operation, ops.AddConstraint):
+        model = getattr(operation, "model_name", "?")
+        constraint = getattr(operation, "constraint", None)
+        constraint_name = getattr(constraint, "name", "?")
+        return Issue(
+            rule_id="RV004",
+            severity=Severity.INFO,
+            operation=f"AddConstraint({model}.{constraint_name})",
+            message=(
+                f"Rolling back this migration drops constraint "
+                f"'{constraint_name}' on '{model}', removing the integrity "
+                f"guarantee it enforced."
+            ),
+            suggestion=(
+                "Confirm that dropping this constraint on rollback is "
+                "acceptable for your data integrity requirements."
+            ),
+        )
+
+    # Silence the unused import when none of the branches matched.
+    del migrations
+    return None
+
+
+def analyze_reverse_safety(
+    migration: Migration,
+    app_label: Optional[str] = None,
+    migration_name: Optional[str] = None,
+    file_path: Optional[str] = None,
+) -> list[Issue]:
+    """Analyse a migration's **rollback** path for dangerous operations.
+
+    Args:
+        migration: The Django migration to analyse.
+        app_label: The app label (for issue enrichment).
+        migration_name: The migration name (for issue enrichment).
+        file_path: The migration file path (for issue enrichment).
+
+    Returns:
+        A list of ``RV0xx`` issues describing rollback dangers.
+    """
+    issues: list[Issue] = []
+    operations = getattr(migration, "operations", [])
+
+    for idx, operation in enumerate(operations):
+        issue = _check_operation_reverse(operation)
+        if issue is None:
+            continue
+        issue.app_label = app_label
+        issue.migration_name = migration_name
+        issue.file_path = file_path
+        issue.operation_index = idx
+        issues.append(issue)
+
+    logger.debug(
+        "Reverse analysis of %s.%s: %d rollback issue(s)",
+        app_label,
+        migration_name,
+        len(issues),
+    )
+    return issues

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -466,6 +466,7 @@ django_safe_migrations/
 ├── conf.py                  # Configuration handling
 ├── diff.py                  # Git-based diff mode for checking only changed migrations
 ├── interactive.py           # Interactive review mode for triaging issues
+├── reverse.py               # Reverse-migration safety checks (--check-reverse)
 ├── suppression.py           # Inline suppression
 ├── utils.py                 # Shared helpers (before-state resolution, etc.)
 ├── watch.py                 # File watcher for continuous analysis (requires watchdog)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -493,6 +493,31 @@ The cache is **opt-in** and best-effort: an unreadable or corrupt cache file is
 ignored rather than failing the run. The cache file is safe to delete at any
 time and should usually be added to `.gitignore`.
 
+### `--check-reverse`
+
+Also analyse each migration's **rollback** path. A migration can be perfectly
+reversible yet have a backwards path that is destructive in production —
+rolling back an additive migration runs the destructive inverse:
+
+```bash
+python manage.py check_migrations --check-reverse
+```
+
+This emits issues in the `RV0xx` family (separate from the forward `SM0xx`
+rules, and only when the flag is given):
+
+| Rule  | Forward op      | Rollback runs     | Severity |
+| ----- | --------------- | ----------------- | -------- |
+| RV001 | `AddField`      | `DROP COLUMN`     | WARNING  |
+| RV002 | `CreateModel`   | `DROP TABLE`      | WARNING  |
+| RV003 | `AddIndex`      | `DROP INDEX`      | INFO     |
+| RV004 | `AddConstraint` | `DROP CONSTRAINT` | INFO     |
+
+This is distinct from `SM007` / `SM016`, which flag `RunSQL` / `RunPython` that
+cannot be reversed *at all*. Operations whose reverse would need to reconstruct
+lost state (`RemoveField`, `DeleteModel`, `AlterField`) are intentionally out of
+scope to avoid guessing.
+
 ### `--baseline`
 
 Exclude issues that are present in a baseline file:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1991,3 +1991,32 @@ a table to (or from) a composite primary key after the table is created.
 Define the composite primary key when the model is first created. To change an
 existing table, recreate it (e.g. via `SeparateDatabaseAndState` plus raw SQL)
 during a planned migration.
+
+______________________________________________________________________
+
+## Reverse-safety rules (RV0xx)
+
+The `RV0xx` rules are **not** part of the normal forward analysis. They run only
+when you pass `--check-reverse`, and they describe what happens to the database
+when a migration is **rolled back**. A migration can be perfectly reversible yet
+have a destructive rollback path: rolling back an additive migration runs the
+destructive inverse operation.
+
+These are distinct from `SM007` / `SM016`, which detect `RunSQL` / `RunPython`
+that cannot be reversed *at all*. Operations whose reverse would need to
+reconstruct lost state (`RemoveField`, `DeleteModel`, `AlterField`) are out of
+scope to avoid guessing at the historical schema.
+
+| Rule  | Forward op      | Rollback runs     | Severity | Why it matters                                         |
+| ----- | --------------- | ----------------- | -------- | ------------------------------------------------------ |
+| RV001 | `AddField`      | `DROP COLUMN`     | WARNING  | Rollback drops the column and any data written to it.  |
+| RV002 | `CreateModel`   | `DROP TABLE`      | WARNING  | Rollback drops the whole table and all of its rows.    |
+| RV003 | `AddIndex`      | `DROP INDEX`      | INFO     | `DROP INDEX` takes a brief exclusive lock on rollback. |
+| RV004 | `AddConstraint` | `DROP CONSTRAINT` | INFO     | Rollback removes the integrity guarantee it enforced.  |
+
+### Safe pattern
+
+Treat rollbacks of additive migrations as destructive by design. If a clean
+rollback matters, separate additive and removal steps into distinct migrations,
+or reverse a concurrently-created index with `DROP INDEX CONCURRENTLY` via a
+hand-written `RunSQL` reverse.

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -345,6 +345,35 @@ class TestCommandOptions:
         second = run()
         assert first["issues"] == second["issues"]
 
+    def test_check_reverse_surfaces_rv_issues(self):
+        """--check-reverse adds RV0xx rollback issues to the output."""
+        out = StringIO()
+        try:
+            call_command(
+                "check_migrations",
+                "testapp",
+                format="json",
+                check_reverse=True,
+                stdout=out,
+            )
+        except SystemExit:
+            pass
+
+        data = json.loads(out.getvalue())
+        rv = [i for i in data["issues"] if i["rule_id"].startswith("RV")]
+        assert rv, "expected at least one reverse-safety issue"
+
+    def test_no_reverse_issues_without_flag(self):
+        """Without --check-reverse, no RV0xx issues appear."""
+        out = StringIO()
+        try:
+            call_command("check_migrations", "testapp", format="json", stdout=out)
+        except SystemExit:
+            pass
+
+        data = json.loads(out.getvalue())
+        assert not any(i["rule_id"].startswith("RV") for i in data["issues"])
+
     def test_exclude_apps_removes_detection(self):
         """Test --exclude-apps properly excludes apps from analysis."""
         out = StringIO()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -74,6 +74,12 @@ class TestFingerprint:
             "postgresql", ["SM001", "SM002"]
         )
 
+    def test_differs_by_check_reverse(self):
+        """Toggling reverse analysis changes the fingerprint (RV0xx issues)."""
+        base = compute_fingerprint("postgresql", ["SM001"], check_reverse=False)
+        rev = compute_fingerprint("postgresql", ["SM001"], check_reverse=True)
+        assert base != rev
+
 
 class TestIssueRoundTrip:
     """Issue.to_dict / from_dict round-trips for the cache."""

--- a/tests/unit/test_reverse.py
+++ b/tests/unit/test_reverse.py
@@ -1,0 +1,128 @@
+"""Tests for reverse-migration safety checks (django_safe_migrations.reverse)."""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+from django_safe_migrations.reverse import (
+    _check_operation_reverse,
+    analyze_reverse_safety,
+)
+from django_safe_migrations.rules.base import Severity
+
+
+class _FakeMigration:
+    """Minimal stand-in exposing only ``operations``."""
+
+    def __init__(self, operations):
+        self.operations = operations
+
+
+class TestCheckOperationReverse:
+    """Per-operation reverse classification."""
+
+    def test_add_field_is_rv001(self):
+        """A forward AddField reverses to a destructive DROP COLUMN."""
+        op = migrations.AddField("Order", "total", models.IntegerField(default=0))
+        issue = _check_operation_reverse(op)
+        assert issue is not None
+        assert issue.rule_id == "RV001"
+        assert issue.severity is Severity.WARNING
+        assert "Order" in issue.message and "total" in issue.message
+
+    def test_create_model_is_rv002(self):
+        """A forward CreateModel reverses to DROP TABLE."""
+        op = migrations.CreateModel(
+            "Invoice", fields=[("id", models.AutoField(primary_key=True))]
+        )
+        issue = _check_operation_reverse(op)
+        assert issue is not None
+        assert issue.rule_id == "RV002"
+        assert issue.severity is Severity.WARNING
+        assert "Invoice" in issue.message
+
+    def test_add_index_is_rv003(self):
+        """A forward AddIndex reverses to DROP INDEX (a brief lock)."""
+        op = migrations.AddIndex(
+            "Order", models.Index(fields=["total"], name="order_total_idx")
+        )
+        issue = _check_operation_reverse(op)
+        assert issue is not None
+        assert issue.rule_id == "RV003"
+        assert issue.severity is Severity.INFO
+        assert "order_total_idx" in issue.message
+
+    def test_add_constraint_is_rv004(self):
+        """A forward AddConstraint reverses to DROP CONSTRAINT."""
+        op = migrations.AddConstraint(
+            "Order",
+            models.UniqueConstraint(fields=["total"], name="order_total_uniq"),
+        )
+        issue = _check_operation_reverse(op)
+        assert issue is not None
+        assert issue.rule_id == "RV004"
+        assert issue.severity is Severity.INFO
+        assert "order_total_uniq" in issue.message
+
+    def test_remove_field_is_out_of_scope(self):
+        """The RemoveField reverse needs lost state and is intentionally skipped."""
+        op = migrations.RemoveField("Order", "total")
+        assert _check_operation_reverse(op) is None
+
+    def test_alter_field_is_out_of_scope(self):
+        """The AlterField reverse needs the old field and is skipped."""
+        op = migrations.AlterField("Order", "total", models.BigIntegerField())
+        assert _check_operation_reverse(op) is None
+
+
+class TestAnalyzeReverseSafety:
+    """The migration-level reverse pass."""
+
+    def test_collects_and_enriches(self):
+        """Issues are collected and enriched with location metadata."""
+        mig = _FakeMigration(
+            [
+                migrations.AddField("Order", "total", models.IntegerField(default=0)),
+                migrations.RemoveField("Order", "old"),  # skipped
+                migrations.CreateModel(
+                    "Invoice", fields=[("id", models.AutoField(primary_key=True))]
+                ),
+            ]
+        )
+        issues = analyze_reverse_safety(
+            mig,
+            app_label="shop",
+            migration_name="0005_things",
+            file_path="/x/0005_things.py",
+        )
+
+        assert [i.rule_id for i in issues] == ["RV001", "RV002"]
+        for issue in issues:
+            assert issue.app_label == "shop"
+            assert issue.migration_name == "0005_things"
+            assert issue.file_path == "/x/0005_things.py"
+        # operation_index points at the forward op (CreateModel is index 2).
+        assert issues[1].operation_index == 2
+
+    def test_no_operations_no_issues(self):
+        """A migration with no reversible-danger ops yields nothing."""
+        mig = _FakeMigration([migrations.RemoveField("Order", "total")])
+        assert analyze_reverse_safety(mig) == []
+
+
+class TestAnalyzerIntegration:
+    """The analyzer only emits RV issues when check_reverse is enabled."""
+
+    def test_check_reverse_off_by_default(self):
+        """Without the flag, no RV issues are produced for testapp."""
+        from django_safe_migrations.analyzer import MigrationAnalyzer
+
+        issues = MigrationAnalyzer().analyze_app("testapp")
+        assert not any(i.rule_id.startswith("RV") for i in issues)
+
+    def test_check_reverse_emits_rv_issues(self):
+        """With the flag, testapp's additive migrations surface RV issues."""
+        from django_safe_migrations.analyzer import MigrationAnalyzer
+
+        issues = MigrationAnalyzer(check_reverse=True).analyze_app("testapp")
+        assert any(i.rule_id.startswith("RV") for i in issues)


### PR DESCRIPTION
Third of the v0.7.1 medium-priority DX batch. (Rebased on top of the merged caching PR #66.)

## What
`--check-reverse` analyses each migration's **rollback** path. A migration can be perfectly *reversible* (Django can generate the backwards operations) yet have a backwards path that is destructive in production: rolling back an additive migration runs the destructive inverse.

New `RV0xx` family (emitted **only** when the flag is given; never part of normal forward analysis, so they can't be confused with `SM0xx`):

| Rule  | Forward op      | Rollback runs     | Severity |
|-------|-----------------|-------------------|----------|
| RV001 | `AddField`      | `DROP COLUMN`     | WARNING  |
| RV002 | `CreateModel`   | `DROP TABLE`      | WARNING  |
| RV003 | `AddIndex`      | `DROP INDEX`      | INFO     |
| RV004 | `AddConstraint` | `DROP CONSTRAINT` | INFO     |

## Why distinct from SM007/SM016
`SM007`/`SM016` flag `RunSQL`/`RunPython` that **cannot be reversed at all**. `--check-reverse` is about reverses that *succeed* but are **dangerous**. Operations whose reverse needs reconstructed historical state (`RemoveField`, `DeleteModel`, `AlterField`) are intentionally out of scope to avoid guessing.

## Changes
- **`reverse.py`** (new): `analyze_reverse_safety()` + `_check_operation_reverse()`.
- **`analyzer.py`**: `check_reverse` flag; runs the reverse pass per migration after the forward rules.
- **Cache correctness**: `compute_fingerprint()` now folds in `check_reverse`, so `--cache --check-reverse` can never serve a cached result that omits/includes RV issues incorrectly.
- **CLI + management command**: `--check-reverse` flag.
- **Tests**: reverse unit (per-op classification, out-of-scope ops, enrichment) + analyzer integration (RV only with the flag) + command integration + a cache fingerprint-variance test.
- **Docs**: README, `configuration.md` (RV table), `rules.md` (RV family section), `architecture.md`, CHANGELOG `[Unreleased]`.

## Verification
821 passed, 19 skipped · pre-commit green (black/isort/flake8/bandit/mypy/mdformat).
