### PR TITLE
feat: --classify-phase (deployment-phase classification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`AddIndex` → `DROP INDEX`), `RV004` (`AddConstraint` → `DROP CONSTRAINT`).
   Distinct from `SM007`/`SM016` (which flag operations that cannot be reversed
   at all); fires only when the flag is given.
+- **`--classify-phase`.** Classify each migration into a deployment phase —
+  `expand` (additive), `contract` (destructive / in-place), `data`
+  (`RunPython`/`RunSQL`), `mixed`, or `empty` — to support expand–contract
+  (blue-green / rolling) deploys. Informational report mode (console or
+  `--format=json`); always exits 0.
 
 ## [0.7.0] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ python manage.py check_migrations --cache
 # Reverse safety - check whether rolling back is destructive
 python manage.py check_migrations --check-reverse
 
+# Deployment phase - classify migrations as expand/contract/data
+python manage.py check_migrations --classify-phase
+
 # Baseline - suppress existing issues
 python manage.py check_migrations --generate-baseline .migration-baseline.json
 python manage.py check_migrations --baseline .migration-baseline.json
@@ -243,6 +246,7 @@ repos:
 | `--cache`                  | Cache results to speed up repeat runs (`.dsm_cache.json`)     |
 | `--cache-file PATH`        | Use a custom cache file path (implies `--cache`)              |
 | `--check-reverse`          | Also check the rollback path for destructive ops (RV0xx)      |
+| `--classify-phase`         | Classify migrations as expand/contract/data/mixed and exit    |
 | `--baseline FILE`          | Exclude issues present in baseline file                       |
 | `--generate-baseline FILE` | Generate baseline file from current issues                    |
 | `--interactive`            | Interactively review each issue                               |

--- a/django_safe_migrations/classify.py
+++ b/django_safe_migrations/classify.py
@@ -1,0 +1,218 @@
+"""Deployment-phase classification (``--classify-phase``).
+
+Classifies each migration into a deployment **phase** to support
+expand–contract (a.k.a. blue-green / rolling) deploys, where schema changes are
+split so old and new application code can run simultaneously:
+
+- **expand** — purely additive, backward-compatible operations (``AddField``,
+  ``CreateModel``, ``AddIndex``, ``AddConstraint``). Safe to deploy *before*
+  the code that uses them.
+- **contract** — destructive or in-place operations that require the old code
+  to be gone first (``RemoveField``, ``DeleteModel``, ``Rename*``,
+  ``AlterField``, …). Safe to deploy *after* the new code is fully rolled out.
+- **data** — data migrations (``RunPython`` / ``RunSQL``).
+- **mixed** — a migration that combines more than one of the above. The usual
+  advice is to split it so each phase can be deployed independently.
+- **empty** — no schema/data operations (e.g. only ``AlterModelOptions``).
+
+This is an *informational* classifier; the phase of an in-place ``AlterField``
+is necessarily heuristic (it is treated as ``contract`` — the conservative
+"deploy after code" choice).
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from django.db.migrations import Migration
+
+logger = logging.getLogger("django_safe_migrations")
+
+
+class Phase(Enum):
+    """A migration's deployment phase."""
+
+    EXPAND = "expand"
+    CONTRACT = "contract"
+    DATA = "data"
+    MIXED = "mixed"
+    EMPTY = "empty"
+
+
+# Operations whose reverse needs no historical state are matched by class name
+# to avoid importing django.contrib.postgres (which may pull in psycopg).
+_CONCURRENT_EXPAND = {"AddIndexConcurrently"}
+_CONCURRENT_CONTRACT = {"RemoveIndexConcurrently"}
+
+
+def classify_operation(operation: object) -> Optional[str]:
+    """Classify a single operation as ``expand`` / ``contract`` / ``data``.
+
+    Args:
+        operation: A Django migration operation.
+
+    Returns:
+        The category string, or ``None`` for operations that do not affect the
+        deployment phase (Python-only model option changes, etc.).
+    """
+    from django.db.migrations import operations as o
+
+    name = type(operation).__name__
+    if name in _CONCURRENT_EXPAND:
+        return "expand"
+    if name in _CONCURRENT_CONTRACT:
+        return "contract"
+
+    if isinstance(operation, (o.AddField, o.CreateModel, o.AddIndex, o.AddConstraint)):
+        return "expand"
+    if isinstance(
+        operation,
+        (
+            o.RemoveField,
+            o.DeleteModel,
+            o.RemoveIndex,
+            o.RemoveConstraint,
+            o.RenameField,
+            o.RenameModel,
+            o.AlterField,
+            o.AlterUniqueTogether,
+            o.AlterIndexTogether,
+            o.AlterModelTable,
+            o.AlterOrderWithRespectTo,
+        ),
+    ):
+        return "contract"
+    if isinstance(operation, (o.RunPython, o.RunSQL)):
+        return "data"
+    return None
+
+
+def classify_migration(migration: Migration) -> tuple[Phase, dict[str, int]]:
+    """Classify a whole migration by aggregating its operations.
+
+    Recurses one level into ``SeparateDatabaseAndState.database_operations`` so
+    schema work hidden inside the wrapper is counted.
+
+    Args:
+        migration: The Django migration to classify.
+
+    Returns:
+        A ``(Phase, counts)`` tuple where ``counts`` maps each category to the
+        number of operations in it.
+    """
+    from django.db import migrations as mig_module
+
+    counts = {"expand": 0, "contract": 0, "data": 0}
+
+    def _tally(op: object) -> None:
+        category = classify_operation(op)
+        if category is not None:
+            counts[category] += 1
+
+    for operation in getattr(migration, "operations", []):
+        _tally(operation)
+        if isinstance(operation, mig_module.SeparateDatabaseAndState):
+            for db_op in operation.database_operations or []:
+                _tally(db_op)
+
+    present = {key for key, value in counts.items() if value}
+    if not present:
+        phase = Phase.EMPTY
+    elif present == {"expand"}:
+        phase = Phase.EXPAND
+    elif present == {"contract"}:
+        phase = Phase.CONTRACT
+    elif present == {"data"}:
+        phase = Phase.DATA
+    else:
+        phase = Phase.MIXED
+
+    return phase, counts
+
+
+def classify_all(
+    app_labels: Optional[list[str]] = None,
+    exclude_apps: Optional[list[str]] = None,
+) -> list[dict[str, Any]]:
+    """Classify every migration on disk (optionally filtered by app).
+
+    Args:
+        app_labels: If given, only classify these apps.
+        exclude_apps: App labels to skip.
+
+    Returns:
+        A list of ``{app_label, migration_name, phase, counts}`` dicts, sorted
+        by app label then migration name.
+    """
+    from django.db.migrations.loader import MigrationLoader
+
+    exclude = set(exclude_apps or [])
+    only = set(app_labels) if app_labels else None
+
+    loader = MigrationLoader(None, ignore_no_migrations=True)
+    results: list[dict[str, Any]] = []
+
+    for (app, name), migration in loader.disk_migrations.items():
+        if app in exclude:
+            continue
+        if only is not None and app not in only:
+            continue
+        phase, counts = classify_migration(migration)
+        results.append(
+            {
+                "app_label": app,
+                "migration_name": name,
+                "phase": phase.value,
+                "counts": counts,
+            }
+        )
+
+    results.sort(key=lambda r: (r["app_label"], r["migration_name"]))
+    logger.debug("Classified %d migration(s)", len(results))
+    return results
+
+
+def render_report(results: list[dict[str, Any]], fmt: str, stream: Any) -> None:
+    """Render a classification report.
+
+    Args:
+        results: The output of :func:`classify_all`.
+        fmt: ``"json"`` for machine-readable output, anything else for a
+            console table.
+        stream: A writable text stream.
+    """
+    if fmt == "json":
+        import json
+
+        stream.write(json.dumps({"migrations": results}, indent=2) + "\n")
+        return
+
+    if not results:
+        stream.write("No migrations found to classify.\n")
+        return
+
+    app_w = max(len(r["app_label"]) for r in results)
+    name_w = max(len(r["migration_name"]) for r in results)
+    app_w = max(app_w, len("App"))
+    name_w = max(name_w, len("Migration"))
+
+    header = f"{'App':<{app_w}}  {'Migration':<{name_w}}  Phase"
+    stream.write(header + "\n")
+    stream.write("-" * len(header) + "\n")
+    for r in results:
+        stream.write(
+            f"{r['app_label']:<{app_w}}  "
+            f"{r['migration_name']:<{name_w}}  "
+            f"{r['phase']}\n"
+        )
+
+    # Summary counts by phase.
+    summary: dict[str, int] = {}
+    for r in results:
+        summary[r["phase"]] = summary.get(r["phase"], 0) + 1
+    stream.write("\n")
+    parts = [f"{phase}: {count}" for phase, count in sorted(summary.items())]
+    stream.write("Summary — " + ", ".join(parts) + "\n")

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -269,6 +269,14 @@ Documentation: https://django-safe-migrations.readthedocs.io/
             "operations (RV0xx issues)"
         ),
     )
+    parser.add_argument(
+        "--classify-phase",
+        action="store_true",
+        help=(
+            "Classify each migration's deployment phase "
+            "(expand/contract/data/mixed) and exit"
+        ),
+    )
 
     args: Namespace = parser.parse_args(argv)
 
@@ -321,6 +329,16 @@ Documentation: https://django-safe-migrations.readthedocs.io/
             "staticfiles",
         ]
         exclude_apps = list(set(exclude_apps + django_apps))
+
+    # Handle --classify-phase: report deployment phases and exit (no analysis).
+    if args.classify_phase:
+        from django_safe_migrations.classify import classify_all, render_report
+
+        results = classify_all(
+            app_labels=list(args.app_labels) or None, exclude_apps=exclude_apps
+        )
+        render_report(results, args.format, sys.stdout)
+        return 0
 
     # Create analyzer
     db_vendor_override = args.database_vendor or get_database_vendor()

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -177,6 +177,14 @@ class Command(BaseCommand):
                 "operations (RV0xx issues)"
             ),
         )
+        parser.add_argument(
+            "--classify-phase",
+            action="store_true",
+            help=(
+                "Classify each migration's deployment phase "
+                "(expand/contract/data/mixed) and exit"
+            ),
+        )
 
     def list_rules(self, output_format: str) -> None:
         """List all available rules.
@@ -312,6 +320,16 @@ class Command(BaseCommand):
                 "staticfiles",
             ]
             exclude_apps = list(set(exclude_apps + django_apps))
+
+        # Handle --classify-phase: report deployment phases and exit.
+        if options.get("classify_phase"):
+            from django_safe_migrations.classify import classify_all, render_report
+
+            results = classify_all(
+                app_labels=list(app_labels) or None, exclude_apps=exclude_apps
+            )
+            render_report(results, output_format, self.stdout)
+            return
 
         # Create analyzer
         analyzer = MigrationAnalyzer(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,6 +462,7 @@ django_safe_migrations/
 ├── apps.py                  # Django AppConfig
 ├── baseline.py              # Baseline support for suppressing known issues
 ├── cache.py                 # Opt-in result cache (dependency-aware, fingerprinted)
+├── classify.py              # Deployment-phase classification (--classify-phase)
 ├── cli.py                   # Standalone CLI
 ├── conf.py                  # Configuration handling
 ├── diff.py                  # Git-based diff mode for checking only changed migrations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,6 +518,29 @@ cannot be reversed *at all*. Operations whose reverse would need to reconstruct
 lost state (`RemoveField`, `DeleteModel`, `AlterField`) are intentionally out of
 scope to avoid guessing.
 
+### `--classify-phase`
+
+Classify each migration into a deployment **phase** to help order
+expand–contract (blue-green / rolling) deploys, then exit. No safety analysis is
+run and the exit code is always `0`:
+
+```bash
+python manage.py check_migrations --classify-phase
+python manage.py check_migrations --classify-phase --format=json
+```
+
+| Phase      | Operations                                             | Deploy…             |
+| ---------- | ------------------------------------------------------ | ------------------- |
+| `expand`   | `AddField`, `CreateModel`, `AddIndex`, `AddConstraint` | before the new code |
+| `contract` | `RemoveField`, `DeleteModel`, `Rename*`, `AlterField`  | after the new code  |
+| `data`     | `RunPython`, `RunSQL`                                  | per data plan       |
+| `mixed`    | more than one of the above                             | split it first      |
+| `empty`    | only Python-only changes (e.g. `AlterModelOptions`)    | anytime             |
+
+`--classify-phase` honours app-label arguments and `--exclude-apps`. The phase
+of an in-place `AlterField` is heuristic — it is reported as `contract` (the
+conservative "deploy after code" choice).
+
 ### `--baseline`
 
 Exclude issues that are present in a baseline file:

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -374,6 +374,26 @@ class TestCommandOptions:
         data = json.loads(out.getvalue())
         assert not any(i["rule_id"].startswith("RV") for i in data["issues"])
 
+    def test_classify_phase_json(self):
+        """--classify-phase emits per-migration phases and exits 0 (no analysis)."""
+        out = StringIO()
+        # Informational mode: must not raise SystemExit even though testapp has
+        # unsafe migrations.
+        call_command(
+            "check_migrations",
+            "testapp",
+            format="json",
+            classify_phase=True,
+            stdout=out,
+        )
+        data = json.loads(out.getvalue())
+        assert "migrations" in data
+        assert data["migrations"], "expected classified migrations"
+        valid = {"expand", "contract", "data", "mixed", "empty"}
+        for m in data["migrations"]:
+            assert m["app_label"] == "testapp"
+            assert m["phase"] in valid
+
     def test_exclude_apps_removes_detection(self):
         """Test --exclude-apps properly excludes apps from analysis."""
         out = StringIO()

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -1,0 +1,179 @@
+"""Tests for deployment-phase classification (django_safe_migrations.classify)."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+from django.db import migrations, models
+
+from django_safe_migrations.classify import (
+    Phase,
+    classify_all,
+    classify_migration,
+    classify_operation,
+    render_report,
+)
+
+
+class _FakeMigration:
+    def __init__(self, operations):
+        self.operations = operations
+
+
+class TestClassifyOperation:
+    """Per-operation category classification."""
+
+    def test_add_field_is_expand(self):
+        """An AddField is an additive (expand) operation."""
+        op = migrations.AddField("Order", "total", models.IntegerField(default=0))
+        assert classify_operation(op) == "expand"
+
+    def test_create_model_is_expand(self):
+        """A CreateModel is additive."""
+        op = migrations.CreateModel(
+            "Invoice", fields=[("id", models.AutoField(primary_key=True))]
+        )
+        assert classify_operation(op) == "expand"
+
+    def test_remove_field_is_contract(self):
+        """A RemoveField requires the old code to be gone first (contract)."""
+        assert (
+            classify_operation(migrations.RemoveField("Order", "total")) == "contract"
+        )
+
+    def test_rename_field_is_contract(self):
+        """A RenameField is an in-place change needing coordination."""
+        op = migrations.RenameField("Order", "total", "grand_total")
+        assert classify_operation(op) == "contract"
+
+    def test_alter_field_is_contract(self):
+        """An AlterField is treated conservatively as contract."""
+        op = migrations.AlterField("Order", "total", models.BigIntegerField())
+        assert classify_operation(op) == "contract"
+
+    def test_run_python_is_data(self):
+        """A RunPython operation is a data operation."""
+        assert classify_operation(migrations.RunPython(migrations.RunPython.noop)) == (
+            "data"
+        )
+
+    def test_alter_model_options_is_neutral(self):
+        """Python-only model option changes do not affect the phase."""
+        op = migrations.AlterModelOptions("Order", options={"ordering": ["id"]})
+        assert classify_operation(op) is None
+
+
+class TestClassifyMigration:
+    """Whole-migration aggregation."""
+
+    def test_only_expand(self):
+        """A migration with only additive ops is EXPAND."""
+        mig = _FakeMigration(
+            [
+                migrations.AddField("Order", "a", models.IntegerField(default=0)),
+                migrations.AddIndex(
+                    "Order", models.Index(fields=["a"], name="order_a_idx")
+                ),
+            ]
+        )
+        phase, counts = classify_migration(mig)
+        assert phase is Phase.EXPAND
+        assert counts["expand"] == 2
+
+    def test_only_contract(self):
+        """A migration with only removals is CONTRACT."""
+        mig = _FakeMigration([migrations.RemoveField("Order", "a")])
+        assert classify_migration(mig)[0] is Phase.CONTRACT
+
+    def test_only_data(self):
+        """A data-only migration is DATA."""
+        mig = _FakeMigration([migrations.RunPython(migrations.RunPython.noop)])
+        assert classify_migration(mig)[0] is Phase.DATA
+
+    def test_mixed(self):
+        """Combining expand and contract yields MIXED."""
+        mig = _FakeMigration(
+            [
+                migrations.AddField("Order", "a", models.IntegerField(default=0)),
+                migrations.RemoveField("Order", "b"),
+            ]
+        )
+        assert classify_migration(mig)[0] is Phase.MIXED
+
+    def test_empty(self):
+        """A migration with only neutral ops is EMPTY."""
+        mig = _FakeMigration(
+            [migrations.AlterModelOptions("Order", options={"ordering": ["id"]})]
+        )
+        assert classify_migration(mig)[0] is Phase.EMPTY
+
+    def test_recurses_into_separate_database_and_state(self):
+        """database_operations inside SeparateDatabaseAndState are counted."""
+        mig = _FakeMigration(
+            [
+                migrations.SeparateDatabaseAndState(
+                    database_operations=[migrations.RemoveField("Order", "a")]
+                )
+            ]
+        )
+        assert classify_migration(mig)[0] is Phase.CONTRACT
+
+
+class TestClassifyAll:
+    """Loader-based classification of the test project."""
+
+    def test_classifies_testapp(self):
+        """The testapp migrations are classified with valid phase labels."""
+        results = classify_all(app_labels=["testapp"])
+        assert results
+        valid = {p.value for p in Phase}
+        for r in results:
+            assert r["app_label"] == "testapp"
+            assert r["phase"] in valid
+
+    def test_exclude_apps(self):
+        """Excluded apps are omitted from the results."""
+        results = classify_all(exclude_apps=["testapp"])
+        assert all(r["app_label"] != "testapp" for r in results)
+
+
+class TestRenderReport:
+    """Report rendering."""
+
+    def test_json_output(self):
+        """JSON output is parseable and wraps a migrations list."""
+        results = [
+            {
+                "app_label": "shop",
+                "migration_name": "0001_initial",
+                "phase": "expand",
+                "counts": {"expand": 1, "contract": 0, "data": 0},
+            }
+        ]
+        out = StringIO()
+        render_report(results, "json", out)
+        data = json.loads(out.getvalue())
+        assert data["migrations"][0]["phase"] == "expand"
+
+    def test_console_output(self):
+        """Console output includes the phase and a summary line."""
+        results = [
+            {
+                "app_label": "shop",
+                "migration_name": "0001_initial",
+                "phase": "expand",
+                "counts": {"expand": 1, "contract": 0, "data": 0},
+            }
+        ]
+        out = StringIO()
+        render_report(results, "console", out)
+        text = out.getvalue()
+        assert "expand" in text
+        assert "Summary" in text
+
+    def test_console_empty(self):
+        """An empty result set renders a friendly message."""
+        out = StringIO()
+        render_report([], "console", out)
+        assert "No migrations" in out.getvalue()


### PR DESCRIPTION
Fourth of the v0.7.1 medium-priority DX batch.

## What
`--classify-phase` classifies each migration into a deployment **phase** to support expand–contract (blue-green / rolling) deploys, where schema changes are split so old and new application code can run simultaneously. It's an informational report mode (always exits 0, no safety analysis).

| Phase      | Operations                                              | Deploy…             |
|------------|---------------------------------------------------------|---------------------|
| `expand`   | `AddField`, `CreateModel`, `AddIndex`, `AddConstraint`  | before the new code |
| `contract` | `RemoveField`, `DeleteModel`, `Rename*`, `AlterField`   | after the new code  |
| `data`     | `RunPython`, `RunSQL`                                   | per data plan       |
| `mixed`    | more than one of the above                              | split it first      |
| `empty`    | only Python-only changes (e.g. `AlterModelOptions`)     | anytime             |

```text
App      Migration                Phase
---------------------------------------
testapp  0001_initial             expand
testapp  0005_drop_column         contract
testapp  0006_run_sql_no_reverse  data

Summary — contract: 1, data: 1, expand: 4
```

## Changes
- **`classify.py`** (new): `Phase` enum, `classify_operation()`, `classify_migration()` (recurses into `SeparateDatabaseAndState`), loader-based `classify_all()`, and `render_report()` (console table + `--format=json`). Concurrent index ops are matched by class name to avoid importing `django.contrib.postgres` (psycopg-free).
- **CLI + management command**: `--classify-phase` early-exit report mode; honours app-label args and `--exclude-apps`. Self-contained — it does not touch the analyzer.
- **Tests**: classify unit (per-op categories, aggregation incl. mixed/empty, SDS recursion, loader pass, JSON/console rendering) + command integration.
- **Docs**: README (example + options table), `configuration.md` (phase table + heuristic note), `architecture.md`, CHANGELOG `[Unreleased]`.

## Notes
The phase of an in-place `AlterField` is necessarily heuristic; it's reported as `contract` (the conservative "deploy after code" choice), documented as such.

## Verification
840 passed, 19 skipped · pre-commit green (black/isort/flake8/bandit/mypy/mdformat).
