### PR TITLE
feat: github-pr reporter (Markdown PR-comment output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`RunPython`/`RunSQL`), `mixed`, or `empty` — to support expand–contract
   (blue-green / rolling) deploys. Informational report mode (console or
   `--format=json`); always exits 0.
+- **`--format=github-pr` reporter.** Renders a Markdown summary grouped by
+  migration file, suitable for posting as a single pull-request comment (e.g.
+  `gh pr comment --body-file`). Performs no network I/O; reports
+  "No migration safety issues found." when clean so it doubles as a green check.
 
 ## [0.7.0] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ python manage.py check_migrations --fail-on-warning
 # GitLab Code Quality output
 python manage.py check_migrations --format=gitlab
 
+# Markdown summary to post as a PR comment
+python manage.py check_migrations --format=github-pr > comment.md
+
 # Diff mode - only check changed migrations
 python manage.py check_migrations --diff
 python manage.py check_migrations --diff main
@@ -232,27 +235,27 @@ repos:
 
 ### Command Options
 
-| Option                     | Description                                                   |
-| -------------------------- | ------------------------------------------------------------- |
-| `--format`                 | Output format: `console`, `json`, `github`, `gitlab`, `sarif` |
-| `--output`, `-o`           | Output file path (defaults to stdout)                         |
-| `--fail-on-warning`        | Exit with error code on warnings                              |
-| `--new-only`               | Only check unapplied migrations                               |
-| `--no-suggestions`         | Hide fix suggestions                                          |
-| `--exclude-apps`           | Apps to exclude from checking                                 |
-| `--include-django-apps`    | Include Django's built-in apps                                |
-| `--diff [BASE_REF]`        | Only check migrations changed since BASE_REF (default: main)  |
-| `--since-commit COMMIT`    | Only check migrations committed in COMMIT..HEAD (no worktree) |
-| `--cache`                  | Cache results to speed up repeat runs (`.dsm_cache.json`)     |
-| `--cache-file PATH`        | Use a custom cache file path (implies `--cache`)              |
-| `--check-reverse`          | Also check the rollback path for destructive ops (RV0xx)      |
-| `--classify-phase`         | Classify migrations as expand/contract/data/mixed and exit    |
-| `--baseline FILE`          | Exclude issues present in baseline file                       |
-| `--generate-baseline FILE` | Generate baseline file from current issues                    |
-| `--interactive`            | Interactively review each issue                               |
-| `--verbose`                | Show progress information during analysis                     |
-| `--watch`                  | Watch migration files and re-run on changes                   |
-| `--list-rules`             | List all available rules and exit                             |
+| Option                     | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `--format`                 | Output: `console`, `json`, `github`, `github-pr`, `gitlab`, `sarif` |
+| `--output`, `-o`           | Output file path (defaults to stdout)                               |
+| `--fail-on-warning`        | Exit with error code on warnings                                    |
+| `--new-only`               | Only check unapplied migrations                                     |
+| `--no-suggestions`         | Hide fix suggestions                                                |
+| `--exclude-apps`           | Apps to exclude from checking                                       |
+| `--include-django-apps`    | Include Django's built-in apps                                      |
+| `--diff [BASE_REF]`        | Only check migrations changed since BASE_REF (default: main)        |
+| `--since-commit COMMIT`    | Only check migrations committed in COMMIT..HEAD (no worktree)       |
+| `--cache`                  | Cache results to speed up repeat runs (`.dsm_cache.json`)           |
+| `--cache-file PATH`        | Use a custom cache file path (implies `--cache`)                    |
+| `--check-reverse`          | Also check the rollback path for destructive ops (RV0xx)            |
+| `--classify-phase`         | Classify migrations as expand/contract/data/mixed and exit          |
+| `--baseline FILE`          | Exclude issues present in baseline file                             |
+| `--generate-baseline FILE` | Generate baseline file from current issues                          |
+| `--interactive`            | Interactively review each issue                                     |
+| `--verbose`                | Show progress information during analysis                           |
+| `--watch`                  | Watch migration files and re-run on changes                         |
+| `--list-rules`             | List all available rules and exit                                   |
 
 ### Programmatic Usage
 

--- a/django_safe_migrations/cli.py
+++ b/django_safe_migrations/cli.py
@@ -149,7 +149,7 @@ Documentation: https://django-safe-migrations.readthedocs.io/
     )
     parser.add_argument(
         "--format",
-        choices=["console", "json", "github", "gitlab", "sarif"],
+        choices=["console", "json", "github", "github-pr", "gitlab", "sarif"],
         default="console",
         help="Output format (default: console)",
     )

--- a/django_safe_migrations/management/commands/check_migrations.py
+++ b/django_safe_migrations/management/commands/check_migrations.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--format",
-            choices=["console", "json", "github", "gitlab", "sarif"],
+            choices=["console", "json", "github", "github-pr", "gitlab", "sarif"],
             default="console",
             help="Output format (default: console)",
         )

--- a/django_safe_migrations/reporters/__init__.py
+++ b/django_safe_migrations/reporters/__init__.py
@@ -3,6 +3,7 @@
 from django_safe_migrations.reporters.base import BaseReporter
 from django_safe_migrations.reporters.console import ConsoleReporter
 from django_safe_migrations.reporters.github import GitHubReporter
+from django_safe_migrations.reporters.github_pr import GitHubPRReporter
 from django_safe_migrations.reporters.gitlab import GitLabReporter
 from django_safe_migrations.reporters.json_reporter import JsonReporter
 from django_safe_migrations.reporters.sarif import SarifReporter
@@ -12,6 +13,7 @@ __all__ = [
     "ConsoleReporter",
     "JsonReporter",
     "GitHubReporter",
+    "GitHubPRReporter",
     "GitLabReporter",
     "SarifReporter",
     "get_reporter",
@@ -22,7 +24,8 @@ def get_reporter(format_name: str, **kwargs: object) -> BaseReporter:
     """Get a reporter instance by format name.
 
     Args:
-        format_name: One of 'console', 'json', 'github', 'gitlab', 'sarif'.
+        format_name: One of 'console', 'json', 'github', 'github-pr',
+            'gitlab', 'sarif'.
         **kwargs: Additional arguments to pass to the reporter.
 
     Returns:
@@ -35,6 +38,7 @@ def get_reporter(format_name: str, **kwargs: object) -> BaseReporter:
         "console": ConsoleReporter,
         "json": JsonReporter,
         "github": GitHubReporter,
+        "github-pr": GitHubPRReporter,
         "gitlab": GitLabReporter,
         "sarif": SarifReporter,
     }

--- a/django_safe_migrations/reporters/github_pr.py
+++ b/django_safe_migrations/reporters/github_pr.py
@@ -1,0 +1,129 @@
+"""GitHub pull-request comment reporter.
+
+Emits a Markdown summary suitable for posting as a single pull-request comment,
+grouped by migration file. Unlike the ``github`` reporter (which emits
+``::error file=...::`` workflow commands that become inline annotations), this
+reporter produces a human-readable comment body that a CI step posts with, e.g.::
+
+    python manage.py check_migrations --format=github-pr > comment.md
+    gh pr comment "$PR_NUMBER" --body-file comment.md
+
+It performs no network I/O and needs no credentials — keeping it pure and
+testable; posting is left to the CI step.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, TextIO
+
+from django_safe_migrations.reporters.base import BaseReporter
+
+if TYPE_CHECKING:
+    from django_safe_migrations.rules.base import Issue
+
+_TITLE = "Django Safe Migrations"
+_FOOTER = (
+    "<sub>Reported by "
+    '<a href="https://github.com/YasserShkeir/django-safe-migrations">'
+    "django-safe-migrations</a></sub>"
+)
+# Severity sort order (errors first) for stable, useful grouping.
+_SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
+
+
+def _escape_cell(text: str) -> str:
+    """Make *text* safe to drop into a Markdown table cell."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\r", " ")
+        .replace("\n", " ")
+        .strip()
+    )
+
+
+class GitHubPRReporter(BaseReporter):
+    """Reporter that outputs a Markdown PR-comment body."""
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        """Initialize the GitHub PR-comment reporter.
+
+        Args:
+            stream: Output stream. Defaults to sys.stdout.
+        """
+        super().__init__(stream or sys.stdout)
+
+    def report(self, issues: list[Issue]) -> str:
+        """Generate a Markdown PR-comment report.
+
+        Args:
+            issues: List of issues to report.
+
+        Returns:
+            The Markdown report as a string.
+        """
+        if not issues:
+            output = (
+                f"## {_TITLE}\n\n"
+                "No migration safety issues found.\n\n"
+                f"{_FOOTER}\n"
+            )
+            self.write(output)
+            return output
+
+        errors = sum(1 for i in issues if i.severity.value == "error")
+        warnings = sum(1 for i in issues if i.severity.value == "warning")
+        infos = sum(1 for i in issues if i.severity.value == "info")
+
+        # Group issues by migration file (preserving a stable order).
+        by_file: dict[str, list[Issue]] = {}
+        for issue in issues:
+            key = issue.file_path or "(unknown migration)"
+            by_file.setdefault(key, []).append(issue)
+
+        lines: list[str] = [f"## {_TITLE}", ""]
+        lines.append(self._summary_line(len(issues), errors, warnings, infos))
+        lines.append("")
+
+        for file_path in sorted(by_file):
+            file_issues = sorted(
+                by_file[file_path],
+                key=lambda i: (
+                    _SEVERITY_ORDER.get(i.severity.value, 9),
+                    i.line_number or 0,
+                    i.rule_id,
+                ),
+            )
+            lines.append(f"### `{file_path}`")
+            lines.append("")
+            lines.append("| Severity | Rule | Line | Message |")
+            lines.append("| --- | --- | --- | --- |")
+            for issue in file_issues:
+                line_no = str(issue.line_number) if issue.line_number else "—"
+                lines.append(
+                    f"| {issue.severity.value.upper()} "
+                    f"| {issue.rule_id} "
+                    f"| {line_no} "
+                    f"| {_escape_cell(issue.message)} |"
+                )
+            lines.append("")
+
+        lines.append(_FOOTER)
+        output = "\n".join(lines) + "\n"
+        self.write(output)
+        return output
+
+    @staticmethod
+    def _summary_line(total: int, errors: int, warnings: int, infos: int) -> str:
+        """Build the one-line summary of issue counts."""
+        parts = []
+        if errors:
+            parts.append(f"{errors} error{'s' if errors != 1 else ''}")
+        if warnings:
+            parts.append(f"{warnings} warning{'s' if warnings != 1 else ''}")
+        if infos:
+            parts.append(f"{infos} info")
+        breakdown = ", ".join(parts)
+        noun = "issue" if total == 1 else "issues"
+        return f"Found **{total} {noun}** — {breakdown}."

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,6 +225,23 @@ reporter = SarifReporter()
 reporter.report(issues)
 ```
 
+### GitHubPRReporter
+
+Outputs a Markdown summary (grouped by migration file) suitable for posting as a
+single pull-request comment. It performs no network I/O — a CI step posts the
+rendered body, e.g. `gh pr comment "$PR" --body-file comment.md`.
+
+```python
+from django_safe_migrations import MigrationAnalyzer
+from django_safe_migrations.reporters.github_pr import GitHubPRReporter
+
+analyzer = MigrationAnalyzer()
+issues = analyzer.analyze_all()
+
+reporter = GitHubPRReporter()
+reporter.report(issues)
+```
+
 ### Using get_reporter()
 
 ```python
@@ -234,6 +251,7 @@ from django_safe_migrations.reporters import get_reporter
 reporter = get_reporter("console", show_suggestions=True)
 reporter = get_reporter("json")
 reporter = get_reporter("github")
+reporter = get_reporter("github-pr")
 reporter = get_reporter("gitlab")
 reporter = get_reporter("sarif")
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,8 @@ This document describes the high-level architecture of django-safe-migrations.
                     ▼             ▼             ▼
               ┌────────────────────────────────────┐
               │ Reporters                          │
-              │ (console/json/github/gitlab/sarif) │
+              │ (console/json/github/github-pr/    │
+              │  gitlab/sarif)                     │
               └────────────────────────────────────┘
 ```
 
@@ -479,7 +480,8 @@ django_safe_migrations/
 │   ├── base.py              # BaseReporter
 │   ├── console.py           # ConsoleReporter
 │   ├── json_reporter.py     # JsonReporter
-│   ├── github.py            # GitHubReporter
+│   ├── github.py            # GitHubReporter (workflow annotations)
+│   ├── github_pr.py         # GitHubPRReporter (Markdown PR comment)
 │   ├── gitlab.py            # GitLabReporter (GitLab Code Quality)
 │   └── sarif.py             # SarifReporter (SARIF code scanning)
 └── rules/

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -91,6 +91,37 @@ jobs:
 
 Using `--format=github` creates annotations that appear directly in your pull request files view and check runs.
 
+### GitHub PR Comment
+
+Using `--format=github-pr` renders a Markdown summary (grouped by migration
+file) that you can post as a single, sticky pull-request comment. The reporter
+does no network I/O — a workflow step posts the rendered body:
+
+```yaml
+on: [pull_request]
+
+jobs:
+  migration-safety:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # required to post the comment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install django-safe-migrations
+      - name: Render report
+        run: python manage.py check_migrations --format=github-pr > dsm-comment.md
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body-file dsm-comment.md
+```
+
+The comment reports "No migration safety issues found." when the run is clean,
+so it doubles as a green check.
+
 ## GitLab CI
 
 ### Basic Setup

--- a/tests/integration/test_command.py
+++ b/tests/integration/test_command.py
@@ -169,6 +169,16 @@ class TestOutputFormats:
         # GitHub format should use ::error:: or ::warning:: annotations
         assert "::error" in output or "::warning" in output
 
+    def test_github_pr_output_format(self):
+        """Test the github-pr format emits a Markdown comment body."""
+        out = StringIO()
+        with pytest.raises(SystemExit):
+            call_command("check_migrations", "testapp", format="github-pr", stdout=out)
+
+        output = out.getvalue()
+        assert "## Django Safe Migrations" in output
+        assert "| Severity | Rule | Line | Message |" in output
+
     def test_json_output_structure(self):
         """Test JSON output has correct structure."""
         out = StringIO()

--- a/tests/unit/test_reporters.py
+++ b/tests/unit/test_reporters.py
@@ -372,6 +372,13 @@ class TestGetReporter:
         reporter = get_reporter("gitlab")
         assert isinstance(reporter, GitLabReporter)
 
+    def test_get_github_pr_reporter(self):
+        """Test getting the GitHub PR-comment reporter."""
+        from django_safe_migrations.reporters.github_pr import GitHubPRReporter
+
+        reporter = get_reporter("github-pr")
+        assert isinstance(reporter, GitHubPRReporter)
+
     def test_invalid_format(self):
         """Test that invalid format raises error."""
         with pytest.raises(ValueError) as exc_info:
@@ -616,3 +623,60 @@ class TestGitLabReporter:
 
         data = json.loads(output)
         assert data[0]["description"] == "Adding NOT NULL field 'email' without default"
+
+
+class TestGitHubPRReporter:
+    """Tests for the GitHub PR-comment (Markdown) reporter."""
+
+    def _reporter(self, stream):
+        from django_safe_migrations.reporters.github_pr import GitHubPRReporter
+
+        return GitHubPRReporter(stream=stream)
+
+    def test_renders_title_and_summary(self, sample_issues):
+        """Output has the title and a summary counting errors/warnings."""
+        out = StringIO()
+        output = self._reporter(out).report(sample_issues)
+
+        assert "## Django Safe Migrations" in output
+        # 2 errors (SM001, SM010) + 1 warning (SM002) in the fixture.
+        assert "2 errors" in output
+        assert "1 warning" in output
+
+    def test_groups_by_file_with_tables(self, sample_issues):
+        """Issues are grouped under per-file headers as Markdown tables."""
+        output = self._reporter(StringIO()).report(sample_issues)
+
+        assert "### `myapp/migrations/0002_add_email.py`" in output
+        assert "| Severity | Rule | Line | Message |" in output
+        assert "| ERROR | SM001 | 15 |" in output
+
+    def test_unknown_file_bucket(self):
+        """An issue with no file_path falls under the unknown bucket."""
+        issue = Issue(
+            rule_id="SM999",
+            severity=Severity.INFO,
+            operation="x",
+            message="no file here",
+        )
+        output = self._reporter(StringIO()).report([issue])
+        assert "(unknown migration)" in output
+
+    def test_escapes_pipe_in_message(self):
+        """A pipe in the message is escaped so the table is not broken."""
+        issue = Issue(
+            rule_id="SM050",
+            severity=Severity.ERROR,
+            operation="RunSQL",
+            message="DROP DATABASE foo | bar",
+            file_path="app/migrations/0001_x.py",
+            line_number=3,
+        )
+        output = self._reporter(StringIO()).report([issue])
+        assert "DROP DATABASE foo \\| bar" in output
+
+    def test_no_issues_message(self):
+        """With no issues the comment says so (green-check friendly)."""
+        output = self._reporter(StringIO()).report([])
+        assert "No migration safety issues found" in output
+        assert "## Django Safe Migrations" in output


### PR DESCRIPTION
Fifth and final feature of the v0.7.1 medium-priority DX batch.

## What
Adds `--format=github-pr`, a reporter that renders a **Markdown summary** grouped by migration file, suitable for posting as a single pull-request comment:

```
python manage.py check_migrations --format=github-pr > comment.md
gh pr comment "$PR_NUMBER" --body-file comment.md
```

## Why distinct from `--format=github`
`github` emits `::error file=...::` **workflow commands** that become inline file annotations. `github-pr` produces a **human-readable comment body** (summary line + per-file tables). It performs **no network I/O and needs no credentials** — posting is left to the CI step — so the reporter stays pure and unit-testable.

Example body:
```markdown
## Django Safe Migrations

Found **3 issues** — 1 error, 2 warnings.

### `app/migrations/0005_x.py`

| Severity | Rule | Line | Message |
| --- | --- | --- | --- |
| ERROR | SM002 | 12 | Dropping column 'legacy' ... |
```
When clean it renders "No migration safety issues found.", so it doubles as a green-check comment.

## Changes
- **`reporters/github_pr.py`** (new): `GitHubPRReporter`. Per-file tables sorted by severity → line → rule; table cells escaped (pipes/newlines) so messages can't break the table; stable footer.
- **`reporters/__init__.py`**: register `github-pr` in `get_reporter`.
- **CLI + management command**: add `github-pr` to the `--format` choices.
- **Tests**: reporter unit (title/summary counts, per-file grouping, unknown-file bucket, pipe-escaping, empty case) + `get_reporter` factory + command integration.
- **Docs**: README (example + formats row), `ci_integration.md` (full PR-comment workflow with `permissions: pull-requests: write`), `api.md`, `architecture.md`, CHANGELOG `[Unreleased]`.

## Verification
847 passed, 19 skipped · pre-commit green (black/isort/flake8/bandit/mypy/mdformat).

---

This completes the v0.7.1 medium-priority DX batch (`--since-commit`, caching, `--check-reverse`, `--classify-phase`, `github-pr`). v0.7.1 release to follow.
