### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-05
+
 ### Added
 
 - **`--since-commit COMMIT`.** Check only migrations changed in the committed

--- a/django_safe_migrations/__init__.py
+++ b/django_safe_migrations/__init__.py
@@ -6,7 +6,7 @@ Detect unsafe Django migrations before they break production.
 from django_safe_migrations.analyzer import MigrationAnalyzer
 from django_safe_migrations.rules.base import Issue, Severity
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = [
     "MigrationAnalyzer",
     "Issue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-safe-migrations"
-version = "0.7.0"
+version = "0.7.1"
 description = "Detect unsafe Django migrations before they break production"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## v0.7.1

Bumps `pyproject.toml` + `__init__.py` to **0.7.1** and dates the CHANGELOG section. Merging then tagging `v0.7.1` triggers `publish.yml` (test + version-match + twine gates) → PyPI + GitHub release.

The **medium-priority DX batch** (the v0.7.0 roadmap's "Batch 6"), shipped as PRs #65–69:

| Feature | Flag / format | Summary |
|---------|---------------|---------|
| Incremental check | `--since-commit COMMIT` | Lint only what was **committed** in `COMMIT..HEAD` (ignores the working tree). Mutually exclusive with `--diff`. |
| Result caching | `--cache` / `--cache-file PATH` | Skip re-analysing unchanged migrations. Dependency-aware content hash (file + transitive deps) under a version/vendor/Django/config fingerprint — never serves stale results. |
| Reverse safety | `--check-reverse` | New `RV001–RV004` family: flags rollbacks that run `DROP COLUMN`/`DROP TABLE`/`DROP INDEX`/`DROP CONSTRAINT`. Distinct from SM007/SM016. |
| Deploy phases | `--classify-phase` | Classify each migration as expand / contract / data / mixed / empty for expand–contract deploys. |
| PR comments | `--format=github-pr` | Markdown summary grouped by file, for `gh pr comment --body-file`. No network I/O. |

### New modules
`cache.py`, `reverse.py`, `classify.py`, `reporters/github_pr.py`.

### Verification
847 passed, 19 skipped · pre-commit green · version matches in both files (guarded by `test_version.py`). Docs synced per-PR (README, `configuration.md`, `ci_integration.md`, `api.md`, `rules.md` RV family, `architecture.md`, CHANGELOG).
