### PR TITLE
docs: add Stripe funding tiers to support surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,9 +435,18 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Support
 
-If this project helps you ship safer migrations, consider supporting its development:
+If this project has caught a migration that would have locked a table in production — or saved you an incident at 2am — consider funding its development.
 
-[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-red.svg)](https://www.yasser-shkeir.com/donate)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa.svg)](https://github.com/sponsors/YasserShkeir)
+
+[GitHub Sponsors](https://github.com/sponsors/YasserShkeir) is the most direct route — it charges a 0% platform fee, so the full amount reaches development.
+
+Prefer a card checkout? Fixed Stripe tiers:
+
+- **One-time** — [$5](https://buy.stripe.com/6oUfZbgh17Km5xQ2HzcMM00), [$10](https://buy.stripe.com/bJe00d8Oz4ya8K21DvcMM01), [$25](https://buy.stripe.com/00wfZb5Cn7Km8K21DvcMM02), [$50](https://buy.stripe.com/aFa14h7Kv0hU1hAfulcMM03)
+- **Monthly** — [$5/mo](https://buy.stripe.com/8x2eV76Gr9Su1hAci9cMM04), [$15/mo](https://buy.stripe.com/28EeV7e8TaWy2lE5TLcMM05), [$50/mo](https://buy.stripe.com/bJe8wJ7Kvc0C7FY2HzcMM06)
+
+See the [support page](https://django-safe-migrations.readthedocs.io/en/latest/support/) for corporate sponsorship and non-financial ways to help, or the [donate page](https://www.yasser-shkeir.com/donate) for every option in one place.
 
 ## Acknowledgments
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -6,9 +6,22 @@ Django Safe Migrations is free, open-source software maintained by [Yasser Shkei
 
 ### Financial Support
 
-If django-safe-migrations has helped you ship safer migrations, consider supporting its development:
+If django-safe-migrations has caught a migration that would have locked a table in production — or saved you an incident at 2am — consider supporting its development.
 
-[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-red.svg?style=for-the-badge)](https://www.yasser-shkeir.com/donate)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa.svg?style=for-the-badge)](https://github.com/sponsors/YasserShkeir)
+
+**[GitHub Sponsors](https://github.com/sponsors/YasserShkeir)** is the most direct route. It charges a 0% platform fee, so the full amount reaches development, and it supports both one-time and recurring sponsorship.
+
+Prefer a card checkout? Fixed Stripe tiers are available:
+
+| One-time                                              | Monthly                                                  |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| [$5](https://buy.stripe.com/6oUfZbgh17Km5xQ2HzcMM00)  | [$5/mo](https://buy.stripe.com/8x2eV76Gr9Su1hAci9cMM04)  |
+| [$10](https://buy.stripe.com/bJe00d8Oz4ya8K21DvcMM01) | [$15/mo](https://buy.stripe.com/28EeV7e8TaWy2lE5TLcMM05) |
+| [$25](https://buy.stripe.com/00wfZb5Cn7Km8K21DvcMM02) | [$50/mo](https://buy.stripe.com/bJe8wJ7Kvc0C7FY2HzcMM06) |
+| [$50](https://buy.stripe.com/aFa14h7Kv0hU1hAfulcMM03) |                                                          |
+
+Every option is also collected on the [donate page](https://www.yasser-shkeir.com/donate).
 
 Your support helps cover:
 
@@ -26,12 +39,6 @@ You can also support the project by:
 - **Contribute code** - Submit pull requests for features or fixes
 - **Write documentation** - Improve guides, examples, or translations
 - **Spread the word** - Share with your team, blog about it, or present at meetups
-
-## GitHub Sponsors
-
-You can also sponsor via GitHub:
-
-[Sponsor on GitHub](https://github.com/sponsors/YasserShkeir)
 
 ## Corporate Sponsorship
 


### PR DESCRIPTION
Gives readers a concrete, low-friction way to fund maintenance, and brings this repo's support surfaces in line with the matching PR in `django-smart-ratelimit`.

## Changes

**README.md** — reframes the existing `## Support` section (still near the bottom, after install/usage/config) around what the library actually saves the reader rather than a generic plea. Leads with GitHub Sponsors since it carries a 0% platform fee, then lists fixed Stripe tiers for anyone who prefers a card checkout. Links out to the readthedocs support page (absolute URL, so it resolves on PyPI too) rather than a relative `docs/` path.

**docs/support.md** — same treatment, with the tiers as a table. Also folds the standalone `## GitHub Sponsors` section into `### Financial Support`: the page previously introduced GitHub Sponsors twice, in two different places, with the second mention reading as an afterthought. Now it is stated once, up front. The rest of the page (non-financial support, corporate sponsorship, thank you, current sponsors) is unchanged.

## PyPI metadata

`[project.urls]` already carried a `Funding` key, so PyPI's sidebar "Funding" link needs no change. Recorded for completeness:

| `[project.urls]` | Before | After |
| :--- | :--- | :--- |
| Homepage | present | unchanged |
| Documentation | present | unchanged |
| Repository | present | unchanged |
| Changelog | present | unchanged |
| Funding | `https://www.yasser-shkeir.com/donate` | unchanged |

## Notes

- Seven fixed tiers only (one-time $5/$10/$25/$50, monthly $5/$15/$50). No variable-amount wording anywhere.
- Stripe URLs are live payment links, copied verbatim and verified byte-for-byte against the source list after `mdformat` reflowed the table.
- No version numbers, changelog entries, or release workflows were touched.
- `pre-commit run --all-files` passes clean, with no unrelated files modified.